### PR TITLE
Add alpha ribbon to demo landing page

### DIFF
--- a/apps/demo/src/app/components/LandingPage.tsx
+++ b/apps/demo/src/app/components/LandingPage.tsx
@@ -90,6 +90,7 @@ const LandingPage = () => {
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-r from-blue-500 to-purple-600 text-white">
+      <h4 className="ribbon">So Very Alpha</h4>
       {/* Hero Section */}
       <section className="text-center py-20">
       <img src="/rwoc-logo.png" alt="React Weapons Of Choice Logo" className="mx-auto mb-6 w-32 h-32" />

--- a/apps/demo/src/styles.css
+++ b/apps/demo/src/styles.css
@@ -118,3 +118,35 @@
     @apply font-heading;
   }
 }
+
+.ribbon {
+  margin: 0;
+  padding: 0;
+  background: rebeccapurple;
+  color: white;
+  padding: 1em 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translateX(30%) translateY(0%) rotate(45deg);
+  transform-origin: top left;
+}
+
+.ribbon:before,
+.ribbon:after {
+  content: '';
+  position: absolute;
+  top: 0;
+  margin: 0 -1px; /* tweak */
+  width: 100%;
+  height: 100%;
+  background: rebeccapurple;
+}
+
+.ribbon:before {
+  right: 100%;
+}
+
+.ribbon:after {
+  left: 100%;
+}


### PR DESCRIPTION
Fixes #13

Add an alpha ribbon to the demo landing page to indicate the project is in ALPHA.

* Modify `apps/demo/src/app/components/LandingPage.tsx` to include an `<h4>` element with the class `ribbon` and the text 'So Very Alpha'.
* Update `apps/demo/src/styles.css` to add the CSS for the `.ribbon` class as specified in the issue description.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/14?shareId=2e247655-1af6-4c4f-a24d-da530fc7e155).