### PR TITLE
Update team names and logos; export useErrorHandling hook

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,3 +12,4 @@
 - Prefer named (explicit) exports rather than default exports for clarity, maintainability, and better tooling support.
 - Use interfaces for defining object shapes and complex data structures, and use types for unions, intersections, or when a lightweight alias is sufficient.
 - Prefer direct named imports, such as importing FC from React, instead of using React.FC.
+- Projects should use relative imports to import from other files within the same project.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
+      - name: Prune pnpm store
+        run: pnpm store prune
+
       # Install dependencies
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,16 @@ jobs:
 
       # Install dependencies
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          retry() {
+            for i in {1..3}; do
+              "$@" && break || {
+                echo "Retrying in 10 seconds..."
+                sleep 10
+              }
+            done
+          }
+          retry pnpm install --frozen-lockfile
 
       # Install Playwright Browsers
       - name: Install Playwright Browsers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-
 
+      - name: Prune pnpm store
+        run: pnpm store prune
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,16 @@ jobs:
         run: pnpm store prune
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          retry() {
+            for i in {1..3}; do
+              "$@" && break || {
+                echo "Retrying in 10 seconds..."
+                sleep 10
+              }
+            done
+          }
+          retry pnpm install --frozen-lockfile
 
       - name: Build project
         run: pnpm exec nx build demo --configuration=production

--- a/apps/demo/src/app/components/AppSidebar.tsx
+++ b/apps/demo/src/app/components/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
   PieChart,
   Settings2,
   SquareTerminal,
+  Swords
 } from 'lucide-react';
 
 
@@ -39,17 +40,17 @@ const data = {
   },
   teams: [
     {
-      name: 'Acme Inc',
-      logo: GalleryVerticalEnd,
+      name: 'RWOC Inc',
+      logo: Swords,
       plan: 'Enterprise',
     },
     {
-      name: 'Acme Corp.',
+      name: 'RWOC Corp.',
       logo: AudioWaveform,
       plan: 'Startup',
     },
     {
-      name: 'Evil Corp.',
+      name: 'Other Corp.',
       logo: Command,
       plan: 'Free',
     },

--- a/apps/demo/src/app/hooks/useErrorHandling.ts
+++ b/apps/demo/src/app/hooks/useErrorHandling.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-const useErrorHandling = (definedRoutes: string[]) => {
+export const useErrorHandling = (definedRoutes: string[]) => {
   const [isNotFound, setIsNotFound] = useState(false);
   const location = useLocation();
 
@@ -14,4 +14,3 @@ const useErrorHandling = (definedRoutes: string[]) => {
   return isNotFound;
 };
 
-export default useErrorHandling;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,1 @@
-import { getJestProjectsAsync } from '@nx/jest';
-
-export default async () => ({
-  projects: await getJestProjectsAsync(),
-});
+// Remove this file

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,3 +1,1 @@
-const nxPreset = require('@nx/jest/preset').default;
-
-module.exports = { ...nxPreset };
+// Remove this file

--- a/libs/shared/src/components/ui/accordion.tsx
+++ b/libs/shared/src/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { ChevronDownIcon } from "@radix-ui/react-icons"
 
 const Accordion = AccordionPrimitive.Root

--- a/libs/shared/src/components/ui/accordion.tsx
+++ b/libs/shared/src/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { ChevronDownIcon } from "@radix-ui/react-icons"
 
 const Accordion = AccordionPrimitive.Root

--- a/libs/shared/src/components/ui/alert-dialog.tsx
+++ b/libs/shared/src/components/ui/alert-dialog.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import { cn } from "@rwoc/shared/lib/utils"
-import { buttonVariants } from "@rwoc/shared/components/ui/button"
+import { cn } from "../../lib/utils"
+import { buttonVariants } from "./button"
 
 const AlertDialog = AlertDialogPrimitive.Root
 

--- a/libs/shared/src/components/ui/alert.tsx
+++ b/libs/shared/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",

--- a/libs/shared/src/components/ui/alert.tsx
+++ b/libs/shared/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",

--- a/libs/shared/src/components/ui/avatar.tsx
+++ b/libs/shared/src/components/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,

--- a/libs/shared/src/components/ui/avatar.tsx
+++ b/libs/shared/src/components/ui/avatar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,

--- a/libs/shared/src/components/ui/badge.tsx
+++ b/libs/shared/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/libs/shared/src/components/ui/badge.tsx
+++ b/libs/shared/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/libs/shared/src/components/ui/breadcrumb.tsx
+++ b/libs/shared/src/components/ui/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { ChevronRightIcon, DotsHorizontalIcon } from "@radix-ui/react-icons"
 
 const Breadcrumb = React.forwardRef<

--- a/libs/shared/src/components/ui/breadcrumb.tsx
+++ b/libs/shared/src/components/ui/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { ChevronRightIcon, DotsHorizontalIcon } from "@radix-ui/react-icons"
 
 const Breadcrumb = React.forwardRef<

--- a/libs/shared/src/components/ui/button.tsx
+++ b/libs/shared/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/libs/shared/src/components/ui/button.tsx
+++ b/libs/shared/src/components/ui/button.tsx
@@ -1,8 +1,9 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "../../lib/utils"
 
-import { cn } from "./utils"
+
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/libs/shared/src/components/ui/calendar.tsx
+++ b/libs/shared/src/components/ui/calendar.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { DayPicker } from "react-day-picker"
 
-import { cn } from "@rwoc/shared/lib/utils"
-import { buttonVariants } from "@rwoc/shared/components/ui/button"
+import { cn } from "../../lib/utils"
+import { buttonVariants } from "./button"
 import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons"
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>

--- a/libs/shared/src/components/ui/card.tsx
+++ b/libs/shared/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/libs/shared/src/components/ui/card.tsx
+++ b/libs/shared/src/components/ui/card.tsx
@@ -1,6 +1,7 @@
+import { cn } from "../../lib/utils"
 import * as React from "react"
 
-import { cn } from "./utils"
+
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/libs/shared/src/components/ui/carousel.tsx
+++ b/libs/shared/src/components/ui/carousel.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
 } from "embla-carousel-react"
-import { cn } from "@rwoc/shared/lib/utils"
-import { Button } from "@rwoc/shared/components/ui/button"
+import { cn } from "../../lib/utils"
+import { Button } from "./button"
 import { ArrowLeftIcon, ArrowRightIcon } from "@radix-ui/react-icons"
 
 type CarouselApi = UseEmblaCarouselType[1]

--- a/libs/shared/src/components/ui/chart.tsx
+++ b/libs/shared/src/components/ui/chart.tsx
@@ -8,7 +8,7 @@ import {
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const

--- a/libs/shared/src/components/ui/chart.tsx
+++ b/libs/shared/src/components/ui/chart.tsx
@@ -8,7 +8,7 @@ import {
   ValueType,
 } from "recharts/types/component/DefaultTooltipContent"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const

--- a/libs/shared/src/components/ui/checkbox.tsx
+++ b/libs/shared/src/components/ui/checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { CheckIcon } from "@radix-ui/react-icons"
 
 const Checkbox = React.forwardRef<

--- a/libs/shared/src/components/ui/checkbox.tsx
+++ b/libs/shared/src/components/ui/checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { CheckIcon } from "@radix-ui/react-icons"
 
 const Checkbox = React.forwardRef<

--- a/libs/shared/src/components/ui/command.tsx
+++ b/libs/shared/src/components/ui/command.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
-import { cn } from "@rwoc/shared/lib/utils"
-import { Dialog, DialogContent } from "@rwoc/shared/components/ui/dialog"
+import { cn } from "../../lib/utils"
+import { Dialog, DialogContent } from "./dialog"
 import { MagnifyingGlassIcon } from "@radix-ui/react-icons"
 
 const Command = React.forwardRef<

--- a/libs/shared/src/components/ui/context-menu.tsx
+++ b/libs/shared/src/components/ui/context-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { CheckIcon, ChevronRightIcon, DotFilledIcon } from "@radix-ui/react-icons"
 
 const ContextMenu = ContextMenuPrimitive.Root

--- a/libs/shared/src/components/ui/context-menu.tsx
+++ b/libs/shared/src/components/ui/context-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { CheckIcon, ChevronRightIcon, DotFilledIcon } from "@radix-ui/react-icons"
 
 const ContextMenu = ContextMenuPrimitive.Root

--- a/libs/shared/src/components/ui/dialog.tsx
+++ b/libs/shared/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { Cross2Icon } from "@radix-ui/react-icons"
 
 const Dialog = DialogPrimitive.Root

--- a/libs/shared/src/components/ui/dialog.tsx
+++ b/libs/shared/src/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { Cross2Icon } from "@radix-ui/react-icons"
 
 const Dialog = DialogPrimitive.Root

--- a/libs/shared/src/components/ui/drawer.tsx
+++ b/libs/shared/src/components/ui/drawer.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Drawer = ({
   shouldScaleBackground = true,

--- a/libs/shared/src/components/ui/drawer.tsx
+++ b/libs/shared/src/components/ui/drawer.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Drawer = ({
   shouldScaleBackground = true,

--- a/libs/shared/src/components/ui/dropdown-menu.tsx
+++ b/libs/shared/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { CheckIcon, ChevronRightIcon, DotFilledIcon } from "@radix-ui/react-icons"
 
 const DropdownMenu = DropdownMenuPrimitive.Root

--- a/libs/shared/src/components/ui/dropdown-menu.tsx
+++ b/libs/shared/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,8 @@
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { cn } from "./utils"
+
+import { cn } from "../../lib/utils"
+
 import { CheckIcon, ChevronRightIcon, DotFilledIcon } from "@radix-ui/react-icons"
 
 const DropdownMenu = DropdownMenuPrimitive.Root

--- a/libs/shared/src/components/ui/form.tsx
+++ b/libs/shared/src/components/ui/form.tsx
@@ -12,8 +12,8 @@ import {
   useFormContext,
 } from "react-hook-form"
 
-import { cn } from "@rwoc/shared/lib/utils"
-import { Label } from "@rwoc/shared/components/ui/label"
+import { cn } from "../../lib/utils"
+import { Label } from "./label"
 
 const Form = FormProvider
 

--- a/libs/shared/src/components/ui/hover-card.tsx
+++ b/libs/shared/src/components/ui/hover-card.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const HoverCard = HoverCardPrimitive.Root
 

--- a/libs/shared/src/components/ui/hover-card.tsx
+++ b/libs/shared/src/components/ui/hover-card.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const HoverCard = HoverCardPrimitive.Root
 

--- a/libs/shared/src/components/ui/input-otp.tsx
+++ b/libs/shared/src/components/ui/input-otp.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { MinusIcon } from "@radix-ui/react-icons"
 
 const InputOTP = React.forwardRef<

--- a/libs/shared/src/components/ui/input-otp.tsx
+++ b/libs/shared/src/components/ui/input-otp.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { MinusIcon } from "@radix-ui/react-icons"
 
 const InputOTP = React.forwardRef<

--- a/libs/shared/src/components/ui/input.tsx
+++ b/libs/shared/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {

--- a/libs/shared/src/components/ui/input.tsx
+++ b/libs/shared/src/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {

--- a/libs/shared/src/components/ui/label.tsx
+++ b/libs/shared/src/components/ui/label.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"

--- a/libs/shared/src/components/ui/label.tsx
+++ b/libs/shared/src/components/ui/label.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"

--- a/libs/shared/src/components/ui/menubar.tsx
+++ b/libs/shared/src/components/ui/menubar.tsx
@@ -2,18 +2,18 @@
 
 import * as React from "react"
 import * as MenubarPrimitive from "@radix-ui/react-menubar"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { CheckIcon, ChevronRightIcon, DotFilledIcon } from "@radix-ui/react-icons"
 
-const MenubarMenu = MenubarPrimitive.Menu
+const MenubarMenu: typeof MenubarPrimitive.Menu = MenubarPrimitive.Menu
 
-const MenubarGroup = MenubarPrimitive.Group
+const MenubarGroup: typeof MenubarPrimitive.Group = MenubarPrimitive.Group
 
-const MenubarPortal = MenubarPrimitive.Portal
+const MenubarPortal: typeof MenubarPrimitive.Portal = MenubarPrimitive.Portal
 
-const MenubarSub = MenubarPrimitive.Sub
+const MenubarSub: typeof MenubarPrimitive.Sub = MenubarPrimitive.Sub
 
-const MenubarRadioGroup = MenubarPrimitive.RadioGroup
+const MenubarRadioGroup: typeof MenubarPrimitive.RadioGroup = MenubarPrimitive.RadioGroup
 
 const Menubar = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.Root>,

--- a/libs/shared/src/components/ui/menubar.tsx
+++ b/libs/shared/src/components/ui/menubar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as MenubarPrimitive from "@radix-ui/react-menubar"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { CheckIcon, ChevronRightIcon, DotFilledIcon } from "@radix-ui/react-icons"
 
 const MenubarMenu = MenubarPrimitive.Menu

--- a/libs/shared/src/components/ui/navigation-menu.tsx
+++ b/libs/shared/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { ChevronDownIcon } from "@radix-ui/react-icons"
 
 const NavigationMenu = React.forwardRef<

--- a/libs/shared/src/components/ui/navigation-menu.tsx
+++ b/libs/shared/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { ChevronDownIcon } from "@radix-ui/react-icons"
 
 const NavigationMenu = React.forwardRef<

--- a/libs/shared/src/components/ui/pagination.tsx
+++ b/libs/shared/src/components/ui/pagination.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import { cn } from "@rwoc/shared/lib/utils"
-import { ButtonProps, buttonVariants } from "@rwoc/shared/components/ui/button"
+import { cn } from "../../lib/utils"
+import { ButtonProps, buttonVariants } from "./button"
 import { ChevronLeftIcon, ChevronRightIcon, DotsHorizontalIcon } from "@radix-ui/react-icons"
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (

--- a/libs/shared/src/components/ui/popover.tsx
+++ b/libs/shared/src/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Popover = PopoverPrimitive.Root
 

--- a/libs/shared/src/components/ui/popover.tsx
+++ b/libs/shared/src/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Popover = PopoverPrimitive.Root
 

--- a/libs/shared/src/components/ui/progress.tsx
+++ b/libs/shared/src/components/ui/progress.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,

--- a/libs/shared/src/components/ui/progress.tsx
+++ b/libs/shared/src/components/ui/progress.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,

--- a/libs/shared/src/components/ui/radio-group.tsx
+++ b/libs/shared/src/components/ui/radio-group.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { DotFilledIcon } from "@radix-ui/react-icons"
 
 const RadioGroup = React.forwardRef<

--- a/libs/shared/src/components/ui/radio-group.tsx
+++ b/libs/shared/src/components/ui/radio-group.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { DotFilledIcon } from "@radix-ui/react-icons"
 
 const RadioGroup = React.forwardRef<

--- a/libs/shared/src/components/ui/resizable.tsx
+++ b/libs/shared/src/components/ui/resizable.tsx
@@ -1,7 +1,7 @@
 "use client"
 import * as ResizablePrimitive from "react-resizable-panels"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { DragHandleDots2Icon } from "@radix-ui/react-icons"
 
 const ResizablePanelGroup = ({

--- a/libs/shared/src/components/ui/resizable.tsx
+++ b/libs/shared/src/components/ui/resizable.tsx
@@ -1,7 +1,7 @@
 "use client"
 import * as ResizablePrimitive from "react-resizable-panels"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { DragHandleDots2Icon } from "@radix-ui/react-icons"
 
 const ResizablePanelGroup = ({

--- a/libs/shared/src/components/ui/scroll-area.tsx
+++ b/libs/shared/src/components/ui/scroll-area.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,

--- a/libs/shared/src/components/ui/scroll-area.tsx
+++ b/libs/shared/src/components/ui/scroll-area.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,

--- a/libs/shared/src/components/ui/select.tsx
+++ b/libs/shared/src/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons"
 
 const Select = SelectPrimitive.Root

--- a/libs/shared/src/components/ui/select.tsx
+++ b/libs/shared/src/components/ui/select.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons"
 
 const Select = SelectPrimitive.Root

--- a/libs/shared/src/components/ui/separator.tsx
+++ b/libs/shared/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/libs/shared/src/components/ui/separator.tsx
+++ b/libs/shared/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/libs/shared/src/components/ui/sheet.tsx
+++ b/libs/shared/src/components/ui/sheet.tsx
@@ -3,8 +3,9 @@
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { cn } from "@rwoc/shared/lib/utils"
+
 import { Cross2Icon } from "@radix-ui/react-icons"
+import { cn } from "../../lib/utils"
 
 const Sheet = SheetPrimitive.Root
 

--- a/libs/shared/src/components/ui/sidebar.tsx
+++ b/libs/shared/src/components/ui/sidebar.tsx
@@ -1,22 +1,21 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
-// import { useIsMobile } from "@rwoc/shared/components/hooks/use-mobile"
-// import { cn } from "@rwoc/shared/components/lib/utils"
-import { Button } from "@rwoc/shared/components/ui/button"
-import { Input } from "@rwoc/shared/components/ui/input"
-import { Separator } from "@rwoc/shared/components/ui/separator"
-import { Sheet, SheetContent } from "@rwoc/shared/components/ui/sheet"
-import { Skeleton } from "@rwoc/shared/components/ui/skeleton"
+
+import { Button } from "./button"
+import { Input } from "./input"
+import { Separator } from "./separator"
+import { Sheet, SheetContent } from "./sheet"
+import { Skeleton } from "./skeleton"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@rwoc/shared/components/ui/tooltip"
+} from "./tooltip"
 import { ViewVerticalIcon } from "@radix-ui/react-icons"
-import { useIsMobile } from "@rwoc/shared/hooks/use-mobile"
-import { cn } from "@rwoc/shared/lib/utils"
+import { useIsMobile } from "../../hooks/use-mobile"
+import { cn } from "../../lib/utils"
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7

--- a/libs/shared/src/components/ui/skeleton.tsx
+++ b/libs/shared/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 function Skeleton({
   className,

--- a/libs/shared/src/components/ui/skeleton.tsx
+++ b/libs/shared/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 function Skeleton({
   className,

--- a/libs/shared/src/components/ui/slider.tsx
+++ b/libs/shared/src/components/ui/slider.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SliderPrimitive from "@radix-ui/react-slider"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,

--- a/libs/shared/src/components/ui/slider.tsx
+++ b/libs/shared/src/components/ui/slider.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SliderPrimitive from "@radix-ui/react-slider"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,

--- a/libs/shared/src/components/ui/switch.tsx
+++ b/libs/shared/src/components/ui/switch.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/libs/shared/src/components/ui/switch.tsx
+++ b/libs/shared/src/components/ui/switch.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,

--- a/libs/shared/src/components/ui/table.tsx
+++ b/libs/shared/src/components/ui/table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Table = React.forwardRef<
   HTMLTableElement,

--- a/libs/shared/src/components/ui/table.tsx
+++ b/libs/shared/src/components/ui/table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Table = React.forwardRef<
   HTMLTableElement,

--- a/libs/shared/src/components/ui/tabs.tsx
+++ b/libs/shared/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Tabs = TabsPrimitive.Root
 

--- a/libs/shared/src/components/ui/tabs.tsx
+++ b/libs/shared/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Tabs = TabsPrimitive.Root
 

--- a/libs/shared/src/components/ui/textarea.tsx
+++ b/libs/shared/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const Textarea = React.forwardRef<
   HTMLTextAreaElement,

--- a/libs/shared/src/components/ui/textarea.tsx
+++ b/libs/shared/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const Textarea = React.forwardRef<
   HTMLTextAreaElement,

--- a/libs/shared/src/components/ui/toast.tsx
+++ b/libs/shared/src/components/ui/toast.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 import { Cross2Icon } from "@radix-ui/react-icons"
 
 const ToastProvider = ToastPrimitives.Provider

--- a/libs/shared/src/components/ui/toast.tsx
+++ b/libs/shared/src/components/ui/toast.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 import { Cross2Icon } from "@radix-ui/react-icons"
 
 const ToastProvider = ToastPrimitives.Provider

--- a/libs/shared/src/components/ui/toaster.tsx
+++ b/libs/shared/src/components/ui/toaster.tsx
@@ -6,8 +6,8 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "@rwoc/shared/components/ui/toast"
-import { useToast } from "@rwoc/shared/hooks/use-toast"
+} from "./toast"
+import { useToast } from "../../hooks/use-toast"
 
 export function Toaster() {
   const { toasts } = useToast()

--- a/libs/shared/src/components/ui/toggle-group.tsx
+++ b/libs/shared/src/components/ui/toggle-group.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
 import { type VariantProps } from "class-variance-authority"
 
-import { cn } from "@rwoc/shared/lib/utils"
-import { toggleVariants } from "@rwoc/shared/components/ui/toggle"
+import { cn } from "../../lib/utils"
+import { toggleVariants } from "./toggle"
 
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants>

--- a/libs/shared/src/components/ui/toggle.tsx
+++ b/libs/shared/src/components/ui/toggle.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import * as TogglePrimitive from '@radix-ui/react-toggle';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from '@rwoc/shared/lib/utils';
+import { cn } from "../../lib/utils"
 
 const toggleVariants = cva(
   'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',

--- a/libs/shared/src/components/ui/tooltip.tsx
+++ b/libs/shared/src/components/ui/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
-import { cn } from "@rwoc/shared/lib/utils"
+import { cn } from "./utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
 

--- a/libs/shared/src/components/ui/tooltip.tsx
+++ b/libs/shared/src/components/ui/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
-import { cn } from "./utils"
+import { cn } from "../../lib/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
 

--- a/libs/shared/src/hooks/use-toast.ts
+++ b/libs/shared/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import * as React from "react"
 import type {
   ToastActionElement,
   ToastProps,
-} from "@rwoc/shared/components/ui/toast"
+} from "../components/ui/toast"
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000

--- a/nx.json
+++ b/nx.json
@@ -38,12 +38,6 @@
       "options": {
         "targetName": "e2e"
       }
-    },
-    {
-      "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      }
     }
   ],
   "targetDefaults": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "@nx/devkit": "20.0.0",
     "@nx/eslint": "20.0.0",
     "@nx/eslint-plugin": "20.0.0",
-    "@nx/jest": "20.0.0",
     "@nx/js": "20.0.0",
     "@nx/playwright": "20.0.0",
     "@nx/react": "20.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:affected": "nx affected --target=test",
     "test:all": "nx run-many --target=test --all",
     "test:e2e": "nx e2e",
-    "test": "nx test",
+    "test": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "husky": {
@@ -129,7 +129,6 @@
     "@swc/core": "~1.5.7",
     "@swc/helpers": "~0.5.11",
     "@testing-library/react": "15.0.6",
-    "@types/jest": "^29.5.12",
     "@types/node": "18.16.9",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
@@ -137,7 +136,6 @@
     "@vitest/coverage-v8": "^1.0.4",
     "@vitest/ui": "^1.3.1",
     "autoprefixer": "10.4.13",
-    "babel-jest": "^29.7.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,7 @@ importers:
         version: 1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^2.5.4
-        version: 2.5.4
+        version: 2.5.5
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(typescript@5.5.4)))
@@ -219,9 +219,6 @@ importers:
       '@testing-library/react':
         specifier: 15.0.6
         version: 15.0.6(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/jest':
-        specifier: ^29.5.12
-        version: 29.5.14
       '@types/node':
         specifier: 18.16.9
         version: 18.16.9
@@ -243,9 +240,6 @@ importers:
       autoprefixer:
         specifier: 10.4.13
         version: 10.4.13(postcss@8.4.38)
-      babel-jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@babel/core@7.26.0)
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -3047,8 +3041,8 @@ packages:
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
-  '@types/express-serve-static-core@5.0.1':
-    resolution: {integrity: sha512-CRICJIl0N5cXDONAdlTv5ShATZ4HEwk6kDDIW2/w9qOWKg+NU/5F8wYRWCrONad0/UKkloNSmmyN/wX4rtpbVA==}
+  '@types/express-serve-static-core@5.0.2':
+    resolution: {integrity: sha512-vluaspfvWEtE4vcSDlKRNer52DvOGrB2xv6diXy6UKyKW0lqZiWHGNApSyxOv+8DE5Z27IzVvE7hNkxg7EXIcg==}
 
   '@types/express@4.17.21':
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
@@ -3073,9 +3067,6 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
-
-  '@types/jest@29.5.14':
-    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
@@ -3742,8 +3733,8 @@ packages:
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
-  caniuse-lite@1.0.30001683:
-    resolution: {integrity: sha512-iqmNnThZ0n70mNwvxpEC2nBJ037ZHZUoBI5Gorh1Mw6IlEAZujEoU1tXA628iZfzm7R9FvFzxbfdgml82a3k8Q==}
+  caniuse-lite@1.0.30001684:
+    resolution: {integrity: sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==}
 
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
@@ -4686,7 +4677,7 @@ packages:
     engines: {node: '>=4'}
 
   exit@0.1.2:
-    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1OtherzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
   expand-tilde@2.0.2:
@@ -5312,8 +5303,9 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
-  is-finalizationregistry@1.0.2:
-    resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
+  is-finalizationregistry@1.1.0:
+    resolution: {integrity: sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==}
+    engines: {node: '>= 0.4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -6958,8 +6950,8 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
 
-  reflect.getprototypeof@1.0.6:
-    resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
+  reflect.getprototypeof@1.0.7:
+    resolution: {integrity: sha512-bMvFGIUKlc/eSfXNX+aZ+EL95/EgZzuwA0OBPTbZZDEJw/0AkentjMuM1oiRfwHrshqk4RzdgiTg5CcDalXN5g==}
     engines: {node: '>= 0.4'}
 
   regenerate-unicode-properties@10.2.0:
@@ -7495,8 +7487,8 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tailwind-merge@2.5.4:
-    resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
+  tailwind-merge@2.5.5:
+    resolution: {integrity: sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -7619,8 +7611,8 @@ packages:
     resolution: {integrity: sha512-QUHBFTJGdOwmp0tbOG505xAgOp/YliZP/6UgafFXYZ26WT1bvQmSMJUvkeVSASuJJHbqsFbynTvkd5W8RBTipg==}
     engines: {node: '>=12'}
 
-  ts-api-utils@1.4.0:
-    resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
+  ts-api-utils@1.4.1:
+    resolution: {integrity: sha512-5RU2/lxTA3YUZxju61HO2U6EoZLvBLtmV2mbTvqyu4a/7s7RmJPT+1YekhMVsQhznRWk/czIwDUg+V8Q9ZuG4w==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
@@ -8061,8 +8053,8 @@ packages:
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
 
-  which-builtin-type@1.1.4:
-    resolution: {integrity: sha512-bppkmBSsHFmIMSl8BO9TbsyzsvGjVoppt8xUiGzwiu/bhDCGxnpOKCxgqj6GuyHE0mINMDecBFPlOm2hzY084w==}
+  which-builtin-type@1.2.0:
+    resolution: {integrity: sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==}
     engines: {node: '>= 0.4'}
 
   which-collection@1.0.2:
@@ -11547,7 +11539,7 @@ snapshots:
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
-      '@types/express-serve-static-core': 5.0.1
+      '@types/express-serve-static-core': 5.0.2
       '@types/node': 18.16.9
 
   '@types/connect@3.4.38':
@@ -11597,7 +11589,7 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
-  '@types/express-serve-static-core@5.0.1':
+  '@types/express-serve-static-core@5.0.2':
     dependencies:
       '@types/node': 18.16.9
       '@types/qs': 6.9.17
@@ -11632,11 +11624,6 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
-
-  '@types/jest@29.5.14':
-    dependencies:
-      expect: 29.7.0
-      pretty-format: 29.7.0
 
   '@types/jsdom@20.0.1':
     dependencies:
@@ -11730,7 +11717,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.0(typescript@5.5.4)
+      ts-api-utils: 1.4.1(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -11760,7 +11747,7 @@ snapshots:
       '@typescript-eslint/utils': 8.15.0(eslint@8.57.1)(typescript@5.5.4)
       debug: 4.3.7
       eslint: 8.57.1
-      ts-api-utils: 1.4.0(typescript@5.5.4)
+      ts-api-utils: 1.4.1(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -11777,7 +11764,7 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.4.0(typescript@5.5.4)
+      ts-api-utils: 1.4.1(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -12203,7 +12190,7 @@ snapshots:
   autoprefixer@10.4.13(postcss@8.4.38):
     dependencies:
       browserslist: 4.24.2
-      caniuse-lite: 1.0.30001683
+      caniuse-lite: 1.0.30001684
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -12415,7 +12402,7 @@ snapshots:
 
   browserslist@4.24.2:
     dependencies:
-      caniuse-lite: 1.0.30001683
+      caniuse-lite: 1.0.30001684
       electron-to-chromium: 1.5.64
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
@@ -12486,11 +12473,11 @@ snapshots:
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.24.2
-      caniuse-lite: 1.0.30001683
+      caniuse-lite: 1.0.30001684
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001683: {}
+  caniuse-lite@1.0.30001684: {}
 
   chai@4.5.0:
     dependencies:
@@ -14250,7 +14237,7 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
-  is-finalizationregistry@1.0.2:
+  is-finalizationregistry@1.1.0:
     dependencies:
       call-bind: 1.0.7
 
@@ -14428,7 +14415,7 @@ snapshots:
       define-properties: 1.2.1
       get-intrinsic: 1.2.4
       has-symbols: 1.0.3
-      reflect.getprototypeof: 1.0.6
+      reflect.getprototypeof: 1.0.7
       set-function-name: 2.0.2
 
   jackspeak@3.4.3:
@@ -16130,15 +16117,15 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
-  reflect.getprototypeof@1.0.6:
+  reflect.getprototypeof@1.0.7:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-abstract: 1.23.5
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
-      globalthis: 1.0.4
-      which-builtin-type: 1.1.4
+      gopd: 1.0.1
+      which-builtin-type: 1.2.0
 
   regenerate-unicode-properties@10.2.0:
     dependencies:
@@ -16744,7 +16731,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwind-merge@2.5.4: {}
+  tailwind-merge@2.5.5: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(typescript@5.5.4))):
     dependencies:
@@ -16875,7 +16862,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
-  ts-api-utils@1.4.0(typescript@5.5.4):
+  ts-api-utils@1.4.1(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
 
@@ -17012,7 +16999,7 @@ snapshots:
       gopd: 1.0.1
       has-proto: 1.0.3
       is-typed-array: 1.1.13
-      reflect.getprototypeof: 1.0.6
+      reflect.getprototypeof: 1.0.7
 
   typed-array-length@1.0.7:
     dependencies:
@@ -17021,7 +17008,7 @@ snapshots:
       gopd: 1.0.1
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
-      reflect.getprototypeof: 1.0.6
+      reflect.getprototypeof: 1.0.7
 
   typed-assert@1.0.9: {}
 
@@ -17395,13 +17382,14 @@ snapshots:
       is-string: 1.0.7
       is-symbol: 1.0.4
 
-  which-builtin-type@1.1.4:
+  which-builtin-type@1.2.0:
     dependencies:
+      call-bind: 1.0.7
       function.prototype.name: 1.1.6
       has-tostringtag: 1.0.2
       is-async-function: 2.0.0
       is-date-object: 1.0.5
-      is-finalizationregistry: 1.0.2
+      is-finalizationregistry: 1.1.0
       is-generator-function: 1.0.10
       is-regex: 1.1.4
       is-weakref: 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4686,7 +4686,7 @@ packages:
     engines: {node: '>=4'}
 
   exit@0.1.2:
-    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1OtherzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
 
   expand-tilde@2.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,9 +177,6 @@ importers:
       '@nx/eslint-plugin':
         specifier: 20.0.0
         version: 20.0.0(@babel/traverse@7.25.9)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(@typescript-eslint/parser@8.15.0(eslint@8.57.1)(typescript@5.5.4))(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(nx@20.0.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(typescript@5.5.4)
-      '@nx/jest':
-        specifier: 20.0.0
-        version: 20.0.0(@babel/traverse@7.25.9)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(nx@20.0.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(typescript@5.5.4))(typescript@5.5.4)
       '@nx/js':
         specifier: 20.0.0
         version: 20.0.0(@babel/traverse@7.25.9)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(nx@20.0.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(typescript@5.5.4)
@@ -1616,9 +1613,6 @@ packages:
     peerDependenciesMeta:
       '@zkochan/js-yaml':
         optional: true
-
-  '@nx/jest@20.0.0':
-    resolution: {integrity: sha512-f/O/QXGIjeouXZhuzRvmvfCqmUnu33hM+rRuKab5Ttn2zDgvlGiM4NkyXhBUrmEUdDw+N+LRN/gq1S0GBj4+pw==}
 
   '@nx/js@20.0.0':
     resolution: {integrity: sha512-CiWl9Np+YL55FZiQXIiOqwxU4Gj9l7pQFE3YV/4v1CTSuT+4uHNAS6hr7nSbVZ0Z4YTk0QnDLsxuvsezIG0LfA==}
@@ -5025,9 +5019,6 @@ packages:
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  harmony-reflect@1.6.2:
-    resolution: {integrity: sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==}
-
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
 
@@ -5176,10 +5167,6 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
-
-  identity-obj-proxy@3.0.0:
-    resolution: {integrity: sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==}
-    engines: {node: '>=4'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -7011,10 +6998,6 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-
-  resolve.exports@1.1.0:
-    resolution: {integrity: sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==}
-    engines: {node: '>=10'}
 
   resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
@@ -9888,38 +9871,6 @@ snapshots:
       - debug
       - nx
       - supports-color
-      - verdaccio
-
-  '@nx/jest@20.0.0(@babel/traverse@7.25.9)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(nx@20.0.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(typescript@5.5.4))(typescript@5.5.4)':
-    dependencies:
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@nx/devkit': 20.0.0(nx@20.0.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15)))
-      '@nx/js': 20.0.0(@babel/traverse@7.25.9)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(nx@20.0.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(typescript@5.5.4)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.4)
-      chalk: 4.1.2
-      identity-obj-proxy: 3.0.0
-      jest-config: 29.7.0(@types/node@18.16.9)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(typescript@5.5.4))
-      jest-resolve: 29.7.0
-      jest-util: 29.7.0
-      minimatch: 9.0.3
-      resolve.exports: 1.1.0
-      semver: 7.6.3
-      tslib: 2.8.1
-      yargs-parser: 21.1.1
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - babel-plugin-macros
-      - debug
-      - node-notifier
-      - nx
-      - supports-color
-      - ts-node
-      - typescript
       - verdaccio
 
   '@nx/js@20.0.0(@babel/traverse@7.25.9)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15))(@types/node@18.16.9)(nx@20.0.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.15))(@swc/types@0.1.17)(typescript@5.5.4))(@swc/core@1.5.29(@swc/helpers@0.5.15)))(typescript@5.4.5)':
@@ -13959,8 +13910,6 @@ snapshots:
 
   handle-thing@2.0.1: {}
 
-  harmony-reflect@1.6.2: {}
-
   has-bigints@1.0.2: {}
 
   has-flag@4.0.0: {}
@@ -14133,10 +14082,6 @@ snapshots:
   icss-utils@5.1.0(postcss@8.4.38):
     dependencies:
       postcss: 8.4.38
-
-  identity-obj-proxy@3.0.0:
-    dependencies:
-      harmony-reflect: 1.6.2
 
   ieee754@1.2.1: {}
 
@@ -16181,8 +16126,6 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
-
-  resolve.exports@1.1.0: {}
 
   resolve.exports@2.0.2: {}
 


### PR DESCRIPTION
Revise team names and logos in the AppSidebar for better representation and export the `useErrorHandling` hook for broader usage.