### PR TITLE
Set BASE_URL for demo build in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,9 @@ jobs:
           retry pnpm install --frozen-lockfile
 
       - name: Build project
-        run: pnpm exec nx build demo --configuration=production
+        run: |
+          export BASE_URL='/react-weapons-of-choice/'
+          pnpm exec nx build demo --configuration=production
 
       # Upload artifact for deployment
       - name: Upload to GitHub Pages artifact


### PR DESCRIPTION
Configure the BASE_URL environment variable for the demo build in the GitHub Actions workflow to ensure correct deployment.