### PR TITLE
Fix image paths when deployed to GitHub Pages

### DIFF
--- a/apps/demo/src/app/components/CardDemo.tsx
+++ b/apps/demo/src/app/components/CardDemo.tsx
@@ -30,7 +30,7 @@ const CardDemo = () => {
         </CardHeader>
         <CardContent>
           <img
-            src="/placeholder.svg?height=100&width=200"
+            src="./placeholder.svg?height=100&width=200"
             alt="Placeholder"
             className="w-full h-auto mb-4"
           />
@@ -42,4 +42,3 @@ const CardDemo = () => {
 };
 
 export default CardDemo;
-

--- a/apps/demo/src/app/components/LandingPage.tsx
+++ b/apps/demo/src/app/components/LandingPage.tsx
@@ -93,7 +93,7 @@ const LandingPage = () => {
       <h4 className="ribbon">So Very Alpha</h4>
       {/* Hero Section */}
       <section className="text-center py-20">
-      <img src="/rwoc-logo.png" alt="React Weapons Of Choice Logo" className="mx-auto mb-6 w-32 h-32" />
+      <img src="./rwoc-logo.png" alt="React Weapons Of Choice Logo" className="mx-auto mb-6 w-32 h-32" />
        
         <h1 className="text-5xl font-bold mb-6">
           The Boilerplate That Speeds Up SPA Development


### PR DESCRIPTION
Fixes #25

Update image paths to use relative paths for GitHub Pages deployment.

* **CardDemo.tsx**
  - Update the `src` attribute in the `img` tag to use a relative path.

* **LandingPage.tsx**
  - Update the `src` attribute in the `img` tag to use a relative path.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/26?shareId=5dc65628-c77c-4949-b518-aa12807279ca).