### PR TITLE
Add homepage field to package.json for GitHub Pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/CambridgeMonorail/react-weapons-of-choice.git"
   },
+  "homepage": "https://cambridgemonorail.github.io/react-weapons-of-choice",
   "keywords": [
     "nx",
     "react",


### PR DESCRIPTION
Include a homepage field in package.json to facilitate deployment on GitHub Pages.