### PR TITLE
Add padding to GetStartedSection for improved layout

### DIFF
--- a/apps/demo/src/app/components/landing-page/GetStartedSection.tsx
+++ b/apps/demo/src/app/components/landing-page/GetStartedSection.tsx
@@ -17,7 +17,7 @@ const GetStartedSection: FC<GetStartedSectionProps> = ({ title, steps, buttonTex
   return (
     <section className="text-center py-20 bg-background text-primary w-full">
       <h2 className="text-4xl font-bold mb-6">{title}</h2>
-      <div className="text-left max-w-2xl mx-auto">
+      <div className="text-left max-w-2xl mx-auto px-4 sm:px-0">
         {steps.map((step) => (
           <p key={step.stepNumber} className="text-xl mb-4">
             <strong>Step {step.stepNumber}:</strong> {step.stepDescription}


### PR DESCRIPTION
Introduce padding to the GetStartedSection to enhance the layout and visual appeal.