### PR TITLE
Refactor Tailwind configuration and update Vite CSS options

### DIFF
--- a/apps/demo/tailwind.config.js
+++ b/apps/demo/tailwind.config.js
@@ -1,11 +1,12 @@
 const { createGlobPatternsForDependencies } = require('@nx/react/tailwind');
 const { join } = require('path');
-const { fontFamily } = require("tailwindcss/defaultTheme")
+const { fontFamily } = require('tailwindcss/defaultTheme');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    darkMode: ['class'],
-    content: [
+  presets: [require('../../libs/common-tailwind/tailwind.config.js')],
+  darkMode: ['class'],
+  content: [
     join(
       __dirname,
       '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
@@ -13,86 +14,12 @@ module.exports = {
     ...createGlobPatternsForDependencies(__dirname),
   ],
   theme: {
-  	extend: {
-  		colors: {
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			sidebar: {
-  				DEFAULT: 'hsl(var(--sidebar-background))',
-  				foreground: 'hsl(var(--sidebar-foreground))',
-  				primary: 'hsl(var(--sidebar-primary))',
-  				'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-  				accent: 'hsl(var(--sidebar-accent))',
-  				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-  				border: 'hsl(var(--sidebar-border))',
-  				ring: 'hsl(var(--sidebar-ring))'
-  			}
-  		},
-  		borderRadius: {
-  			lg: '`var(--radius)`',
-  			md: '`calc(var(--radius) - 2px)`',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		fontFamily: {
-  			sans: ['Manrope', ...fontFamily.sans],
-  			heading: ['Oswald', ...fontFamily.sans]
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+    extend: {
+      fontFamily: {
+        sans: ['Manrope', ...fontFamily.sans],
+        heading: ['Oswald', ...fontFamily.sans],
+      },
+    },
   },
-  plugins: [
-    require("tailwindcss-animate")
-  ],
+  plugins: [require('tailwindcss-animate')],
 };

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -17,6 +17,13 @@ export default defineConfig({
     host: 'localhost',
   },
   plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  css: {
+    preprocessorOptions: {
+      css: {
+        additionalData: `@import "../../libs/common-tailwind/src/preflight.css"; @import "../../libs/common-tailwind/src/shadcn-theme.css";`,
+      },
+    },
+  },
   // Uncomment this if you are using workers.
   // worker: {
   //  plugins: [ nxViteTsPaths() ],

--- a/docs/theming-a-new-app.md
+++ b/docs/theming-a-new-app.md
@@ -37,7 +37,7 @@ Modify the tailwind.config.js in your new application to extend the shared confi
 const { join } = require('path');
 
 module.exports = {
-  presets: [require('../../libs/shared/common-tailwind/tailwind.config.js')],
+  presets: [require('../../libs/common-tailwind/tailwind.config.js')],
   content: [
     join(__dirname, 'src/**/*.{js,jsx,ts,tsx,html}'),
     // Automatically include content from dependencies
@@ -74,6 +74,28 @@ In your application's main stylesheet (e.g., styles.css), import the shared Pref
 @import 'libs/shared/common-tailwind/src/lib/shadcn-theme.css';
 
 /* Additional application-specific styles */
+```
+
+Additionally, configure the Vite CSS preprocessor options to ensure proper handling of the imported styles:
+
+```javascript
+// apps/new-app/vite.config.js
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  css: {
+    preprocessorOptions: {
+      css: {
+        additionalData: `
+          @import 'libs/shared/common-tailwind/src/lib/preflight.css';
+          @import 'libs/shared/common-tailwind/src/lib/shadcn-theme.css';
+        `,
+      },
+    },
+  },
+});
 ```
 
 This structure allows you to include both the Preflight styles and the custom Shadcn theme. If you prefer to exclude either, simply omit the corresponding @import statement.

--- a/libs/common-tailwind/tailwind.config.js
+++ b/libs/common-tailwind/tailwind.config.js
@@ -11,7 +11,80 @@ module.exports = {
     ...createGlobPatternsForDependencies(__dirname),
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar-background))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))',
+        },
+      },
+      borderRadius: {
+        lg: '`var(--radius)`',
+        md: '`calc(var(--radius) - 2px)`',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: {
+            height: '0',
+          },
+          to: {
+            height: 'var(--radix-accordion-content-height)',
+          },
+        },
+        'accordion-up': {
+          from: {
+            height: 'var(--radix-accordion-content-height)',
+          },
+          to: {
+            height: '0',
+          },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
Refactor the Tailwind configuration to extend shared styles and streamline the theme setup. Update Vite CSS preprocessor options to properly handle imported styles.