### PR TITLE
Reorder vite-plugin-react-markdown entry in lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,6 @@ importers:
       vaul:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      vite-plugin-react-markdown:
-        specifier: ^0.2.10
-        version: 0.2.10(vite@5.4.11(@types/node@18.16.9)(less@4.1.3)(sass@1.81.0)(stylus@0.64.0)(terser@5.36.0))
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -378,6 +375,9 @@ importers:
       vite-plugin-dts:
         specifier: ~3.8.1
         version: 3.8.3(@types/node@18.16.9)(rollup@4.27.4)(typescript@5.6.3)(vite@5.4.11(@types/node@18.16.9)(less@4.1.3)(sass@1.81.0)(stylus@0.64.0)(terser@5.36.0))
+      vite-plugin-react-markdown:
+        specifier: ^0.2.10
+        version: 0.2.10(vite@5.4.11(@types/node@18.16.9)(less@4.1.3)(sass@1.81.0)(stylus@0.64.0)(terser@5.36.0))
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@18.16.9)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.81.0)(stylus@0.64.0)(terser@5.36.0)


### PR DESCRIPTION
Reorganize the entry for `vite-plugin-react-markdown` in the lockfile for better clarity and consistency.