### PR TITLE
Hero Section: Improve Landing Page CTA Buttons

### DIFF
--- a/apps/demo/src/app/components/landing-page/LandingPage.tsx
+++ b/apps/demo/src/app/components/landing-page/LandingPage.tsx
@@ -36,11 +36,11 @@ export const LandingPage: FC = () => {
           image={logoSrc}
           imageAlt="Logo for the boilerplate"
           ctaPrimary={{
-            text: 'Get Started',
+            text: 'Start Building for Free',
             link: 'https://github.com/CambridgeMonorail/react-weapons-of-choice',
           }}
           ctaSecondary={{
-            text: 'Learn More',
+            text: 'Explore Features',
             onClick: handleScrollToFeatures,
           }}
           layout="left"


### PR DESCRIPTION
Fixes #97

Update the call-to-action buttons in the `LandingPage` component.

* Change `ctaPrimary` text to 'Start Building for Free'.
* Change `ctaSecondary` text to 'Explore Features'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/110?shareId=edc7c1a0-6419-4693-8b19-5fc549d07333).