### PR TITLE
Add button in header to link to Storybook

### DIFF
--- a/apps/demo/src/app/components/landing-page/LandingPage.tsx
+++ b/apps/demo/src/app/components/landing-page/LandingPage.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { Github, Twitter } from 'lucide-react';
 
 import logoSrc from '../../../assets/images/rwoc-logo.png';
-import { Logo } from '../shared/Logo';
+
 import { AboutSection, CommunitySection, DemoSection, FeaturesSection, Footer, GetStartedSection, HeroSection } from '@rwoc/landing';
-import { Tagline } from '@rwoc/shadcnui-blocks';
+import { Logo, Tagline } from '@rwoc/shadcnui-blocks';
 
 
 export const LandingPage: FC = () => {

--- a/libs/shadcnui-blocks/src/index.ts
+++ b/libs/shadcnui-blocks/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/shadcnui-blocks';
 export * from './lib/Tagline';
+export * from './lib/Logo';

--- a/libs/shadcnui-blocks/src/lib/Logo.tsx
+++ b/libs/shadcnui-blocks/src/lib/Logo.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 
 // Define individual logo components
 const ShadcnLogo = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg data-testid="shadcn-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" {...props}>
+  <svg
+    data-testid="shadcn-logo"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 256 256"
+    {...props}
+  >
     <rect width="256" height="256" fill="none" />
     <line
       x1="208"
@@ -39,7 +44,8 @@ const TailwindLogo = (props: React.SVGProps<SVGSVGElement>) => (
 );
 
 const NxLogo = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg data-testid="nx-logo"
+  <svg
+    data-testid="nx-logo"
     role="img"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
@@ -69,6 +75,14 @@ const ReactLogo = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const StorybookLogo = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg data-testid="react-logo" viewBox="0 0 32 32" {...props}>
+    <g fill="currentColor">
+      <path d="M21.786 0.318l-0.161 3.615c-0.005 0.203 0.229 0.328 0.391 0.203l1.411-1.068 1.198 0.932c0.156 0.104 0.365 0 0.375-0.188l-0.135-3.677 1.776-0.135c0.922-0.063 1.708 0.672 1.708 1.599v28.802c0 0.917-0.766 1.646-1.682 1.599l-21.469-0.958c-0.833-0.036-1.505-0.708-1.531-1.547l-1-26.401c-0.052-0.885 0.62-1.646 1.505-1.693l17.599-1.109zM17.693 12.401c0 0.625 4.214 0.318 4.786-0.109 0-4.266-2.292-6.521-6.479-6.521-4.198 0-6.531 2.297-6.531 5.724 0 5.932 8 6.036 8 9.276 0 0.938-0.427 1.469-1.401 1.469-1.281 0-1.802-0.651-1.734-2.88 0-0.479-4.865-0.641-5.026 0-0.359 5.375 2.974 6.932 6.797 6.932 3.724 0 6.63-1.984 6.63-5.573 0-6.359-8.135-6.188-8.135-9.333 0-1.292 0.964-1.464 1.505-1.464 0.604 0 1.667 0.094 1.589 2.49z" />
+    </g>
+  </svg>
+);
+
 // Map of available logos
 const logoMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
   shadcn: ShadcnLogo,
@@ -76,6 +90,7 @@ const logoMap: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
   pnpm: PnpmLogo,
   react: ReactLogo,
   tailwind: TailwindLogo,
+  storybook: StorybookLogo
 };
 
 // Reusable Logo component

--- a/libs/shell/src/lib/Layout.tsx
+++ b/libs/shell/src/lib/Layout.tsx
@@ -106,6 +106,22 @@ export function Layout({ children, sidebarData }: LayoutProps) {
                   <span className="sr-only">GitHub repository</span>
                 </a>
               </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                asChild
+                title="Open Storybook in a new tab"
+                aria-label="Open Storybook in a new tab"
+                data-testid="storybook-link"
+              >
+                <a
+                  href="https://cambridgemonorail.github.io/react-weapons-of-choice/storybook/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <span className="sr-only">Storybook</span>
+                </a>
+              </Button>
             </div>
           </header>
           <div className="flex-1 overflow-auto">

--- a/libs/shell/src/lib/Layout.tsx
+++ b/libs/shell/src/lib/Layout.tsx
@@ -17,6 +17,7 @@ import { Moon, Sun, Github } from 'lucide-react';
 import { useLocation, Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { SidebarProvider as SidebarDataProvider, SidebarData } from './sidebarContext';
+import { Logo } from '@rwoc/shadcnui-blocks';
 
 interface LayoutProps {
   children: ReactNode;
@@ -41,12 +42,14 @@ export function Layout({ children, sidebarData }: LayoutProps) {
           <header
             className="flex h-16 flex-shrink-0 items-center justify-between gap-2 border-b px-4 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 w-full max-w-full"
             data-testid="header"
+            role="banner"
           >
             <div
               className="flex items-center gap-2"
               data-testid="breadcrumb-container"
+              aria-label="Breadcrumb navigation"
             >
-              <SidebarTrigger className="-ml-1" data-testid="sidebar-trigger" />
+              <SidebarTrigger className="-ml-1" data-testid="sidebar-trigger" aria-label="Toggle sidebar" />
               <Separator orientation="vertical" className="mr-2 h-4" />
               <Breadcrumb>
                 <BreadcrumbList>
@@ -60,7 +63,7 @@ export function Layout({ children, sidebarData }: LayoutProps) {
                         data-testid={`breadcrumb-item-${index}`}
                       >
                         {isLast ? (
-                          <BreadcrumbPage>{value}</BreadcrumbPage>
+                          <BreadcrumbPage aria-current="page">{value}</BreadcrumbPage>
                         ) : (
                           <BreadcrumbLink>
                             <Link to={to}>{value}</Link>
@@ -85,6 +88,7 @@ export function Layout({ children, sidebarData }: LayoutProps) {
                 onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
                 title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
                 data-testid="theme-toggle-button"
+                aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
               >
                 <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
                 <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
@@ -96,6 +100,7 @@ export function Layout({ children, sidebarData }: LayoutProps) {
                 asChild
                 title="View GitHub repository"
                 data-testid="github-link"
+                aria-label="View GitHub repository"
               >
                 <a
                   href="https://github.com/CambridgeMonorail/react-weapons-of-choice"
@@ -110,8 +115,8 @@ export function Layout({ children, sidebarData }: LayoutProps) {
                 variant="ghost"
                 size="icon"
                 asChild
-                title="Open Storybook in a new tab"
-                aria-label="Open Storybook in a new tab"
+                title="Open Storybook"
+                aria-label="Open Storybook"
                 data-testid="storybook-link"
               >
                 <a
@@ -119,12 +124,13 @@ export function Layout({ children, sidebarData }: LayoutProps) {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
+                  <Logo name="storybook" className="h-[1.2rem] w-[1.2rem]" />
                   <span className="sr-only">Storybook</span>
                 </a>
               </Button>
             </div>
           </header>
-          <div className="flex-1 overflow-auto">
+          <div className="flex-1 overflow-auto" role="main">
             {children}
           </div>
         </SidebarInset>


### PR DESCRIPTION
Fixes #106

Add a button in the header to link to Storybook.

* Add a new `Button` element in the header section of `libs/shell/src/lib/Layout.tsx`.
* Wrap the `Button` element in an anchor (`<a>`) tag with `href` set to the Storybook URL and `target="_blank"`.
* Add an `aria-label` attribute to the `Button` element with the value "Open Storybook in a new tab".
* Ensure the button is styled consistently with existing header buttons.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/116?shareId=a52a3a0d-0952-4efc-8433-981bd55f8d9b).