### PR TITLE
Landing Page “See It in Action” Section: Refine Copy and CTA

### DIFF
--- a/apps/demo/src/app/components/landing-page/LandingPage.tsx
+++ b/apps/demo/src/app/components/landing-page/LandingPage.tsx
@@ -141,9 +141,9 @@ export const LandingPage: FC = () => {
         data-testid="features-section"
       />
       <DemoSection
-        title="See It in Action"
-        description="Explore a live demo to see how React Weapons of Choice simplifies SPA development."
-        buttonText="View Demo"
+        title="Experience It Yourself"
+        description="Try our live demo to see how effortlessly you can set up and scale your React project with React Weapons of Choice."
+        buttonText="Try the Demo"
         buttonAction={() => navigate('/home')}
         data-testid="demo-section"
       />


### PR DESCRIPTION
Fixes #98

Update the "See It in Action" section copy and CTA button text in the landing page.

* Change the section title to "Experience It Yourself".
* Update the section description to "Try our live demo to see how effortlessly you can set up and scale your React project with React Weapons of Choice."
* Rename the CTA button text to "Try the Demo".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/130?shareId=0f9731a4-5b38-4632-92a9-a553928993b3).