### PR TITLE
Add Storybook stories and JSDoc comments for layout components

### DIFF
--- a/libs/shadcnui/src/components/ui/layout/aspect-ratio/aspect-ratio.stories.tsx
+++ b/libs/shadcnui/src/components/ui/layout/aspect-ratio/aspect-ratio.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AspectRatio } from './aspect-ratio';
+
+const meta: Meta<typeof AspectRatio> = {
+  title: 'Shadcnui/Layout/AspectRatio',
+  component: AspectRatio,
+  tags: ['autodocs'],
+  argTypes: {
+    ratio: {
+      name: 'Ratio',
+      control: 'number',
+      description: 'The aspect ratio of the container',
+    },
+    className: {
+      name: 'Class Name',
+      control: 'text',
+      description: 'Additional Tailwind CSS classes for the container',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AspectRatio>;
+
+/**
+ * This story demonstrates the default usage of the AspectRatio component
+ * with a 16:9 ratio. It can be used as a reference for how to integrate
+ * and customize the AspectRatio component in different contexts.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => (
+    <AspectRatio {...args} ratio={16 / 9}>
+      <div className="bg-gray-200">16:9 Aspect Ratio</div>
+    </AspectRatio>
+  ),
+  args: {
+    className: '',
+  },
+};
+
+/**
+ * This story demonstrates the usage of the AspectRatio component with a 4:3 ratio.
+ */
+export const FourThree: Story = {
+  name: '4:3',
+  render: (args) => (
+    <AspectRatio {...args} ratio={4 / 3}>
+      <div className="bg-gray-200">4:3 Aspect Ratio</div>
+    </AspectRatio>
+  ),
+  args: {
+    className: '',
+  },
+};
+
+/**
+ * This story demonstrates the usage of the AspectRatio component with a 1:1 ratio.
+ */
+export const OneOne: Story = {
+  name: '1:1',
+  render: (args) => (
+    <AspectRatio {...args} ratio={1}>
+      <div className="bg-gray-200">1:1 Aspect Ratio</div>
+    </AspectRatio>
+  ),
+  args: {
+    className: '',
+  },
+};

--- a/libs/shadcnui/src/components/ui/layout/aspect-ratio/aspect-ratio.tsx
+++ b/libs/shadcnui/src/components/ui/layout/aspect-ratio/aspect-ratio.tsx
@@ -1,5 +1,18 @@
 import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
 
+/**
+ * AspectRatio component.
+ *
+ * This component is a wrapper that maintains a consistent aspect ratio for its children.
+ *
+ * @param {number} ratio - The aspect ratio of the container.
+ * @param {string} className - Additional Tailwind CSS classes for the container.
+ *
+ * @example
+ * <AspectRatio ratio={16 / 9} className="bg-gray-200">
+ *   <div>16:9 Aspect Ratio</div>
+ * </AspectRatio>
+ */
 const AspectRatio = AspectRatioPrimitive.Root
 
 export { AspectRatio }

--- a/libs/shadcnui/src/components/ui/layout/collapsible/collapsible.stories.tsx
+++ b/libs/shadcnui/src/components/ui/layout/collapsible/collapsible.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from './collapsible';
+
+const meta: Meta<typeof Collapsible> = {
+  title: 'Shadcnui/Layout/Collapsible',
+  component: Collapsible,
+  tags: ['autodocs'],
+  argTypes: {
+    open: {
+      name: 'Open',
+      control: 'boolean',
+      description: 'Whether the collapsible is open by default',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Collapsible>;
+
+/**
+ * This story demonstrates the default usage of the Collapsible component
+ * with a trigger and content. It can be used as a reference for how to
+ * integrate and customize the Collapsible component in different contexts.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => (
+    <Collapsible {...args}>
+      <CollapsibleTrigger className="bg-gray-200 p-2">Toggle</CollapsibleTrigger>
+      <CollapsibleContent className="p-2">Content</CollapsibleContent>
+    </Collapsible>
+  ),
+  args: {
+    open: false,
+  },
+};
+
+/**
+ * This story demonstrates the Collapsible component in an open state by default.
+ */
+export const OpenByDefault: Story = {
+  name: 'Open By Default',
+  render: (args) => (
+    <Collapsible {...args}>
+      <CollapsibleTrigger className="bg-gray-200 p-2">Toggle</CollapsibleTrigger>
+      <CollapsibleContent className="p-2">Content</CollapsibleContent>
+    </Collapsible>
+  ),
+  args: {
+    open: true,
+  },
+};

--- a/libs/shadcnui/src/components/ui/layout/collapsible/collapsible.tsx
+++ b/libs/shadcnui/src/components/ui/layout/collapsible/collapsible.tsx
@@ -2,10 +2,47 @@
 
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
+/**
+ * Collapsible component.
+ *
+ * This component provides a collapsible container that can be toggled open or closed.
+ *
+ * @param {boolean} open - Whether the collapsible is open by default.
+ * @param {Function} onOpenChange - Callback function when the open state changes.
+ * @param {React.ReactNode} children - The content to be rendered inside the collapsible.
+ *
+ * @example
+ * <Collapsible open={true} onOpenChange={(open) => console.log(open)}>
+ *   <CollapsibleTrigger>Toggle</CollapsibleTrigger>
+ *   <CollapsibleContent>Content</CollapsibleContent>
+ * </Collapsible>
+ */
 const Collapsible = CollapsiblePrimitive.Root
 
+/**
+ * CollapsibleTrigger component.
+ *
+ * This component is used to trigger the opening and closing of the collapsible.
+ *
+ * @param {React.ReactNode} children - The content to be rendered inside the trigger.
+ * @param {string} className - Additional Tailwind CSS classes for the trigger.
+ *
+ * @example
+ * <CollapsibleTrigger className="bg-gray-200 p-2">Toggle</CollapsibleTrigger>
+ */
 const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
 
+/**
+ * CollapsibleContent component.
+ *
+ * This component is used to render the content inside the collapsible.
+ *
+ * @param {React.ReactNode} children - The content to be rendered inside the collapsible.
+ * @param {string} className - Additional Tailwind CSS classes for the content.
+ *
+ * @example
+ * <CollapsibleContent className="p-2">Content</CollapsibleContent>
+ */
 const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/libs/shadcnui/src/components/ui/layout/resizable/resizable.stories.tsx
+++ b/libs/shadcnui/src/components/ui/layout/resizable/resizable.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from './resizable';
+
+const meta: Meta<typeof ResizablePanelGroup> = {
+  title: 'Shadcnui/Layout/Resizable',
+  component: ResizablePanelGroup,
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      name: 'Class Name',
+      control: 'text',
+      description: 'Additional Tailwind CSS classes for the container',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ResizablePanelGroup>;
+
+/**
+ * This story demonstrates the default usage of the ResizablePanelGroup component
+ * with ResizablePanel and ResizableHandle. It can be used as a reference for how to
+ * integrate and customize the ResizablePanelGroup component in different contexts.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => (
+    <ResizablePanelGroup {...args}>
+      <ResizablePanel>
+        <div className="bg-gray-200 p-4">Panel 1</div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel>
+        <div className="bg-gray-200 p-4">Panel 2</div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  ),
+  args: {
+    className: '',
+  },
+};
+
+/**
+ * This story demonstrates the usage of the ResizablePanelGroup component with vertical orientation.
+ */
+export const Vertical: Story = {
+  name: 'Vertical',
+  render: (args) => (
+    <ResizablePanelGroup {...args} className="flex-col">
+      <ResizablePanel>
+        <div className="bg-gray-200 p-4">Panel 1</div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel>
+        <div className="bg-gray-200 p-4">Panel 2</div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  ),
+  args: {
+    className: '',
+  },
+};
+
+/**
+ * This story demonstrates the usage of the ResizablePanelGroup component with multiple panels.
+ */
+export const MultiplePanels: Story = {
+  name: 'Multiple Panels',
+  render: (args) => (
+    <ResizablePanelGroup {...args}>
+      <ResizablePanel>
+        <div className="bg-gray-200 p-4">Panel 1</div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel>
+        <div className="bg-gray-200 p-4">Panel 2</div>
+      </ResizablePanel>
+      <ResizableHandle withHandle />
+      <ResizablePanel>
+        <div className="bg-gray-200 p-4">Panel 3</div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  ),
+  args: {
+    className: '',
+  },
+};

--- a/libs/shadcnui/src/components/ui/layout/resizable/resizable.tsx
+++ b/libs/shadcnui/src/components/ui/layout/resizable/resizable.tsx
@@ -8,20 +8,6 @@ import { DragHandleDots2Icon } from "@radix-ui/react-icons"
  * ResizablePanelGroup component.
  *
  * This component provides a group of resizable panels.
- *
- * @param {string} className - Additional Tailwind CSS classes for the container.
- * @param {React.ComponentProps<typeof ResizablePrimitive.PanelGroup>} props - Props for the ResizablePanelGroup component.
- *
- * @example
- * <ResizablePanelGroup className="custom-class">
- *   <ResizablePanel>
- *     <div>Panel 1</div>
- *   </ResizablePanel>
- *   <ResizableHandle withHandle />
- *   <ResizablePanel>
- *     <div>Panel 2</div>
- *   </ResizablePanel>
- * </ResizablePanelGroup>
  */
 const ResizablePanelGroup = ({
   className,

--- a/libs/shadcnui/src/components/ui/layout/resizable/resizable.tsx
+++ b/libs/shadcnui/src/components/ui/layout/resizable/resizable.tsx
@@ -4,6 +4,25 @@ import * as ResizablePrimitive from "react-resizable-panels"
 import { cn } from "../../../../lib/utils"
 import { DragHandleDots2Icon } from "@radix-ui/react-icons"
 
+/**
+ * ResizablePanelGroup component.
+ *
+ * This component provides a group of resizable panels.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the container.
+ * @param {React.ComponentProps<typeof ResizablePrimitive.PanelGroup>} props - Props for the ResizablePanelGroup component.
+ *
+ * @example
+ * <ResizablePanelGroup className="custom-class">
+ *   <ResizablePanel>
+ *     <div>Panel 1</div>
+ *   </ResizablePanel>
+ *   <ResizableHandle withHandle />
+ *   <ResizablePanel>
+ *     <div>Panel 2</div>
+ *   </ResizablePanel>
+ * </ResizablePanelGroup>
+ */
 const ResizablePanelGroup = ({
   className,
   ...props
@@ -17,8 +36,32 @@ const ResizablePanelGroup = ({
   />
 )
 
+/**
+ * ResizablePanel component.
+ *
+ * This component provides a resizable panel.
+ *
+ * @param {React.ComponentProps<typeof ResizablePrimitive.Panel>} props - Props for the ResizablePanel component.
+ *
+ * @example
+ * <ResizablePanel>
+ *   <div>Panel Content</div>
+ * </ResizablePanel>
+ */
 const ResizablePanel = ResizablePrimitive.Panel
 
+/**
+ * ResizableHandle component.
+ *
+ * This component provides a handle for resizing panels.
+ *
+ * @param {boolean} withHandle - Whether to include a visual handle.
+ * @param {string} className - Additional Tailwind CSS classes for the handle.
+ * @param {React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle>} props - Props for the ResizableHandle component.
+ *
+ * @example
+ * <ResizableHandle withHandle />
+ */
 const ResizableHandle = ({
   withHandle,
   className,

--- a/libs/shadcnui/src/components/ui/layout/scroll-area/scroll-area.stories.tsx
+++ b/libs/shadcnui/src/components/ui/layout/scroll-area/scroll-area.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ScrollArea, ScrollBar } from './scroll-area';
+
+const meta: Meta<typeof ScrollArea> = {
+  title: 'Shadcnui/Layout/ScrollArea',
+  component: ScrollArea,
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      name: 'Class Name',
+      control: 'text',
+      description: 'Additional Tailwind CSS classes for the container',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ScrollArea>;
+
+/**
+ * This story demonstrates the default usage of the ScrollArea component
+ * with a vertical scrollbar. It can be used as a reference for how to
+ * integrate and customize the ScrollArea component in different contexts.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => (
+    <ScrollArea {...args} className="h-64 w-64">
+      <div className="h-96 w-full bg-gray-200">Scrollable Content</div>
+    </ScrollArea>
+  ),
+  args: {
+    className: '',
+  },
+};
+
+/**
+ * This story demonstrates the usage of the ScrollArea component with a horizontal scrollbar.
+ */
+export const Horizontal: Story = {
+  name: 'Horizontal',
+  render: (args) => (
+    <ScrollArea {...args} className="h-64 w-64">
+      <div className="h-full w-96 bg-gray-200">Scrollable Content</div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+  args: {
+    className: '',
+  },
+};
+
+/**
+ * This story demonstrates the usage of the ScrollArea component with both vertical and horizontal scrollbars.
+ */
+export const Both: Story = {
+  name: 'Both',
+  render: (args) => (
+    <ScrollArea {...args} className="h-64 w-64">
+      <div className="h-96 w-96 bg-gray-200">Scrollable Content</div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+  args: {
+    className: '',
+  },
+};

--- a/libs/shadcnui/src/components/ui/layout/scroll-area/scroll-area.tsx
+++ b/libs/shadcnui/src/components/ui/layout/scroll-area/scroll-area.tsx
@@ -7,14 +7,6 @@ import { cn } from "../../../../lib/utils"
  * ScrollArea component.
  *
  * This component provides a scrollable container with customizable scrollbars.
- *
- * @param {string} className - Additional Tailwind CSS classes for the container.
- * @param {React.ReactNode} children - The content to be rendered inside the scrollable area.
- *
- * @example
- * <ScrollArea className="h-64 w-64">
- *   <div className="h-96 w-full bg-gray-200">Scrollable Content</div>
- * </ScrollArea>
  */
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,

--- a/libs/shadcnui/src/components/ui/layout/scroll-area/scroll-area.tsx
+++ b/libs/shadcnui/src/components/ui/layout/scroll-area/scroll-area.tsx
@@ -3,6 +3,19 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "../../../../lib/utils"
 
+/**
+ * ScrollArea component.
+ *
+ * This component provides a scrollable container with customizable scrollbars.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the container.
+ * @param {React.ReactNode} children - The content to be rendered inside the scrollable area.
+ *
+ * @example
+ * <ScrollArea className="h-64 w-64">
+ *   <div className="h-96 w-full bg-gray-200">Scrollable Content</div>
+ * </ScrollArea>
+ */
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
@@ -21,6 +34,17 @@ const ScrollArea = React.forwardRef<
 ))
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
 
+/**
+ * ScrollBar component.
+ *
+ * This component provides a customizable scrollbar for the ScrollArea.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the scrollbar.
+ * @param {string} orientation - The orientation of the scrollbar (vertical or horizontal).
+ *
+ * @example
+ * <ScrollBar orientation="horizontal" />
+ */
 const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>

--- a/libs/shadcnui/src/components/ui/layout/separator/separator.stories.tsx
+++ b/libs/shadcnui/src/components/ui/layout/separator/separator.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Separator } from './separator';
+
+const meta: Meta<typeof Separator> = {
+  title: 'Shadcnui/Layout/Separator',
+  component: Separator,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      name: 'Orientation',
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'The orientation of the separator',
+    },
+    className: {
+      name: 'Class Name',
+      control: 'text',
+      description: 'Additional Tailwind CSS classes for the separator',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Separator>;
+
+/**
+ * This story demonstrates the default usage of the Separator component
+ * with a horizontal orientation. It can be used as a reference for how to
+ * integrate and customize the Separator component in different contexts.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => <Separator {...args} orientation="horizontal" />,
+  args: {
+    className: '',
+  },
+};
+
+/**
+ * This story demonstrates the usage of the Separator component with a vertical orientation.
+ */
+export const Vertical: Story = {
+  name: 'Vertical',
+  render: (args) => <Separator {...args} orientation="vertical" />,
+  args: {
+    className: '',
+  },
+};

--- a/libs/shadcnui/src/components/ui/layout/separator/separator.tsx
+++ b/libs/shadcnui/src/components/ui/layout/separator/separator.tsx
@@ -7,13 +7,6 @@ import { cn } from "../../../../lib/utils"
  * Separator component.
  *
  * This component provides a visual separator between elements, either horizontally or vertically.
- *
- * @param {string} orientation - The orientation of the separator (horizontal or vertical).
- * @param {boolean} decorative - Whether the separator is purely decorative.
- * @param {string} className - Additional Tailwind CSS classes for the separator.
- *
- * @example
- * <Separator orientation="horizontal" className="my-4" />
  */
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/libs/shadcnui/src/components/ui/layout/separator/separator.tsx
+++ b/libs/shadcnui/src/components/ui/layout/separator/separator.tsx
@@ -3,6 +3,18 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
 import { cn } from "../../../../lib/utils"
 
+/**
+ * Separator component.
+ *
+ * This component provides a visual separator between elements, either horizontally or vertically.
+ *
+ * @param {string} orientation - The orientation of the separator (horizontal or vertical).
+ * @param {boolean} decorative - Whether the separator is purely decorative.
+ * @param {string} className - Additional Tailwind CSS classes for the separator.
+ *
+ * @example
+ * <Separator orientation="horizontal" className="my-4" />
+ */
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>

--- a/libs/shadcnui/src/components/ui/layout/sheet/sheet.stories.tsx
+++ b/libs/shadcnui/src/components/ui/layout/sheet/sheet.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { 
+  Sheet, 
+  SheetTrigger, 
+  SheetClose, 
+  SheetPortal, 
+  SheetOverlay, 
+  SheetContent, 
+  SheetHeader, 
+  SheetFooter, 
+  SheetTitle, 
+  SheetDescription 
+} from './sheet';
+
+const meta: Meta<typeof Sheet> = {
+  title: 'Shadcnui/Layout/Sheet',
+  component: Sheet,
+  tags: ['autodocs'],
+  argTypes: {
+    open: {
+      name: 'Open',
+      control: 'boolean',
+      description: 'Whether the sheet is open by default',
+    },
+    side: {
+      name: 'Side',
+      control: 'select',
+      options: ['top', 'bottom', 'left', 'right'],
+      description: 'The side of the screen where the sheet appears',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Sheet>;
+
+/**
+ * This story demonstrates the default usage of the Sheet component
+ * with a trigger and content. It can be used as a reference for how to
+ * integrate and customize the Sheet component in different contexts.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger className="bg-gray-200 p-2">Open Sheet</SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Sheet Title</SheetTitle>
+          <SheetDescription>Sheet Description</SheetDescription>
+        </SheetHeader>
+        <div className="p-2">Sheet Content</div>
+        <SheetFooter>
+          <SheetClose className="bg-gray-200 p-2">Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  args: {
+    open: false,
+    side: 'right',
+  },
+};
+
+/**
+ * This story demonstrates the Sheet component in an open state by default.
+ */
+export const OpenByDefault: Story = {
+  name: 'Open By Default',
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger className="bg-gray-200 p-2">Open Sheet</SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Sheet Title</SheetTitle>
+          <SheetDescription>Sheet Description</SheetDescription>
+        </SheetHeader>
+        <div className="p-2">Sheet Content</div>
+        <SheetFooter>
+          <SheetClose className="bg-gray-200 p-2">Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  args: {
+    open: true,
+    side: 'right',
+  },
+};
+
+/**
+ * This story demonstrates the Sheet component appearing from the left side of the screen.
+ */
+export const FromLeft: Story = {
+  name: 'From Left',
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger className="bg-gray-200 p-2">Open Sheet</SheetTrigger>
+      <SheetContent side="left">
+        <SheetHeader>
+          <SheetTitle>Sheet Title</SheetTitle>
+          <SheetDescription>Sheet Description</SheetDescription>
+        </SheetHeader>
+        <div className="p-2">Sheet Content</div>
+        <SheetFooter>
+          <SheetClose className="bg-gray-200 p-2">Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  args: {
+    open: false,
+    side: 'left',
+  },
+};
+
+/**
+ * This story demonstrates the Sheet component appearing from the top side of the screen.
+ */
+export const FromTop: Story = {
+  name: 'From Top',
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger className="bg-gray-200 p-2">Open Sheet</SheetTrigger>
+      <SheetContent side="top">
+        <SheetHeader>
+          <SheetTitle>Sheet Title</SheetTitle>
+          <SheetDescription>Sheet Description</SheetDescription>
+        </SheetHeader>
+        <div className="p-2">Sheet Content</div>
+        <SheetFooter>
+          <SheetClose className="bg-gray-200 p-2">Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  args: {
+    open: false,
+    side: 'top',
+  },
+};
+
+/**
+ * This story demonstrates the Sheet component appearing from the bottom side of the screen.
+ */
+export const FromBottom: Story = {
+  name: 'From Bottom',
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger className="bg-gray-200 p-2">Open Sheet</SheetTrigger>
+      <SheetContent side="bottom">
+        <SheetHeader>
+          <SheetTitle>Sheet Title</SheetTitle>
+          <SheetDescription>Sheet Description</SheetDescription>
+        </SheetHeader>
+        <div className="p-2">Sheet Content</div>
+        <SheetFooter>
+          <SheetClose className="bg-gray-200 p-2">Close</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  args: {
+    open: false,
+    side: 'bottom',
+  },
+};

--- a/libs/shadcnui/src/components/ui/layout/sheet/sheet.tsx
+++ b/libs/shadcnui/src/components/ui/layout/sheet/sheet.tsx
@@ -7,14 +7,82 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { Cross2Icon } from "@radix-ui/react-icons"
 import { cn } from "../../../../lib/utils"
 
+/**
+ * Sheet component.
+ *
+ * This component provides a sheet dialog that can be used to display content
+ * in a modal-like overlay.
+ *
+ * @param {boolean} open - Whether the sheet is open by default.
+ * @param {React.ReactNode} children - The content to be rendered inside the sheet.
+ *
+ * @example
+ * <Sheet open={true}>
+ *   <SheetTrigger>Open Sheet</SheetTrigger>
+ *   <SheetContent>
+ *     <SheetHeader>
+ *       <SheetTitle>Sheet Title</SheetTitle>
+ *       <SheetDescription>Sheet Description</SheetDescription>
+ *     </SheetHeader>
+ *     <div>Sheet Content</div>
+ *     <SheetFooter>
+ *       <SheetClose>Close</SheetClose>
+ *     </SheetFooter>
+ *   </SheetContent>
+ * </Sheet>
+ */
 const Sheet = SheetPrimitive.Root
 
+/**
+ * SheetTrigger component.
+ *
+ * This component is used to trigger the opening of the sheet.
+ *
+ * @param {React.ReactNode} children - The content to be rendered inside the trigger.
+ * @param {string} className - Additional Tailwind CSS classes for the trigger.
+ *
+ * @example
+ * <SheetTrigger className="bg-gray-200 p-2">Open Sheet</SheetTrigger>
+ */
 const SheetTrigger = SheetPrimitive.Trigger
 
+/**
+ * SheetClose component.
+ *
+ * This component is used to close the sheet.
+ *
+ * @param {React.ReactNode} children - The content to be rendered inside the close button.
+ * @param {string} className - Additional Tailwind CSS classes for the close button.
+ *
+ * @example
+ * <SheetClose className="bg-gray-200 p-2">Close</SheetClose>
+ */
 const SheetClose = SheetPrimitive.Close
 
+/**
+ * SheetPortal component.
+ *
+ * This component provides a portal for rendering the sheet content outside the DOM hierarchy.
+ *
+ * @param {React.ReactNode} children - The content to be rendered inside the portal.
+ *
+ * @example
+ * <SheetPortal>
+ *   <SheetContent>Sheet Content</SheetContent>
+ * </SheetPortal>
+ */
 const SheetPortal = SheetPrimitive.Portal
 
+/**
+ * SheetOverlay component.
+ *
+ * This component provides an overlay for the sheet.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the overlay.
+ *
+ * @example
+ * <SheetOverlay className="bg-black/80" />
+ */
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
@@ -49,6 +117,20 @@ const sheetVariants = cva(
   }
 )
 
+/**
+ * SheetContent component.
+ *
+ * This component provides the content for the sheet.
+ *
+ * @param {string} side - The side of the screen where the sheet appears (top, bottom, left, right).
+ * @param {string} className - Additional Tailwind CSS classes for the content.
+ * @param {React.ReactNode} children - The content to be rendered inside the sheet.
+ *
+ * @example
+ * <SheetContent side="right" className="p-4">
+ *   <div>Sheet Content</div>
+ * </SheetContent>
+ */
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
@@ -74,6 +156,20 @@ const SheetContent = React.forwardRef<
 ))
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
+/**
+ * SheetHeader component.
+ *
+ * This component provides the header for the sheet.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the header.
+ * @param {React.ReactNode} children - The content to be rendered inside the header.
+ *
+ * @example
+ * <SheetHeader className="p-4">
+ *   <SheetTitle>Sheet Title</SheetTitle>
+ *   <SheetDescription>Sheet Description</SheetDescription>
+ * </SheetHeader>
+ */
 const SheetHeader = ({
   className,
   ...props
@@ -88,6 +184,19 @@ const SheetHeader = ({
 )
 SheetHeader.displayName = "SheetHeader"
 
+/**
+ * SheetFooter component.
+ *
+ * This component provides the footer for the sheet.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the footer.
+ * @param {React.ReactNode} children - The content to be rendered inside the footer.
+ *
+ * @example
+ * <SheetFooter className="p-4">
+ *   <SheetClose>Close</SheetClose>
+ * </SheetFooter>
+ */
 const SheetFooter = ({
   className,
   ...props
@@ -102,6 +211,17 @@ const SheetFooter = ({
 )
 SheetFooter.displayName = "SheetFooter"
 
+/**
+ * SheetTitle component.
+ *
+ * This component provides the title for the sheet.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the title.
+ * @param {React.ReactNode} children - The content to be rendered inside the title.
+ *
+ * @example
+ * <SheetTitle className="text-lg font-semibold">Sheet Title</SheetTitle>
+ */
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
@@ -114,6 +234,17 @@ const SheetTitle = React.forwardRef<
 ))
 SheetTitle.displayName = SheetPrimitive.Title.displayName
 
+/**
+ * SheetDescription component.
+ *
+ * This component provides the description for the sheet.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the description.
+ * @param {React.ReactNode} children - The content to be rendered inside the description.
+ *
+ * @example
+ * <SheetDescription className="text-sm">Sheet Description</SheetDescription>
+ */
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>

--- a/libs/shadcnui/src/components/ui/layout/sidebar/sidebar.stories.tsx
+++ b/libs/shadcnui/src/components/ui/layout/sidebar/sidebar.stories.tsx
@@ -1,0 +1,240 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+} from './sidebar';
+
+const meta: Meta<typeof Sidebar> = {
+  title: 'Shadcnui/Layout/Sidebar',
+  component: Sidebar,
+  tags: ['autodocs'],
+  argTypes: {
+    side: {
+      name: 'Side',
+      control: 'select',
+      options: ['left', 'right'],
+      description: 'The side of the screen where the sidebar appears',
+    },
+    variant: {
+      name: 'Variant',
+      control: 'select',
+      options: ['sidebar', 'floating', 'inset'],
+      description: 'The variant of the sidebar',
+    },
+    collapsible: {
+      name: 'Collapsible',
+      control: 'select',
+      options: ['offcanvas', 'icon', 'none'],
+      description: 'The collapsible behavior of the sidebar',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Sidebar>;
+
+/**
+ * This story demonstrates the default usage of the Sidebar component
+ * with various subcomponents. It can be used as a reference for how to
+ * integrate and customize the Sidebar component in different contexts.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => (
+    <SidebarProvider>
+      <Sidebar {...args}>
+        <SidebarHeader>
+          <SidebarTrigger />
+          <SidebarInput placeholder="Search..." />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Group 1</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 1</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 2</SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarSeparator />
+          <SidebarGroup>
+            <SidebarGroupLabel>Group 2</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 3</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 4</SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton>Footer Item 1</SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton>Footer Item 2</SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+      </Sidebar>
+    </SidebarProvider>
+  ),
+  args: {
+    side: 'left',
+    variant: 'sidebar',
+    collapsible: 'offcanvas',
+  },
+};
+
+/**
+ * This story demonstrates the Sidebar component with the floating variant.
+ */
+export const Floating: Story = {
+  name: 'Floating',
+  render: (args) => (
+    <SidebarProvider>
+      <Sidebar {...args}>
+        <SidebarHeader>
+          <SidebarTrigger />
+          <SidebarInput placeholder="Search..." />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Group 1</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 1</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 2</SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarSeparator />
+          <SidebarGroup>
+            <SidebarGroupLabel>Group 2</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 3</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 4</SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton>Footer Item 1</SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton>Footer Item 2</SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+      </Sidebar>
+    </SidebarProvider>
+  ),
+  args: {
+    side: 'left',
+    variant: 'floating',
+    collapsible: 'offcanvas',
+  },
+};
+
+/**
+ * This story demonstrates the Sidebar component with the inset variant.
+ */
+export const Inset: Story = {
+  name: 'Inset',
+  render: (args) => (
+    <SidebarProvider>
+      <Sidebar {...args}>
+        <SidebarHeader>
+          <SidebarTrigger />
+          <SidebarInput placeholder="Search..." />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Group 1</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 1</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 2</SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarSeparator />
+          <SidebarGroup>
+            <SidebarGroupLabel>Group 2</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 3</SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>Item 4</SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton>Footer Item 1</SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton>Footer Item 2</SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+      </Sidebar>
+    </SidebarProvider>
+  ),
+  args: {
+    side: 'left',
+    variant: 'inset',
+    collapsible: 'offcanvas',
+  },
+};

--- a/libs/shadcnui/src/components/ui/layout/sidebar/sidebar.tsx
+++ b/libs/shadcnui/src/components/ui/layout/sidebar/sidebar.tsx
@@ -43,6 +43,22 @@ function useSidebar() {
   return context
 }
 
+/**
+ * SidebarProvider component.
+ *
+ * This component provides context for the sidebar, including state management
+ * and keyboard shortcuts.
+ *
+ * @param {boolean} defaultOpen - Whether the sidebar is open by default.
+ * @param {boolean} open - Controlled open state of the sidebar.
+ * @param {Function} onOpenChange - Callback function when the open state changes.
+ * @param {React.ReactNode} children - The content to be rendered inside the sidebar.
+ *
+ * @example
+ * <SidebarProvider defaultOpen={true}>
+ *   <Sidebar>Content</Sidebar>
+ * </SidebarProvider>
+ */
 const SidebarProvider = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
@@ -152,6 +168,22 @@ const SidebarProvider = React.forwardRef<
 )
 SidebarProvider.displayName = "SidebarProvider"
 
+/**
+ * Sidebar component.
+ *
+ * This component provides a sidebar with various configurations, including
+ * collapsible behavior and different variants.
+ *
+ * @param {string} side - The side of the screen where the sidebar appears (left or right).
+ * @param {string} variant - The variant of the sidebar (sidebar, floating, inset).
+ * @param {string} collapsible - The collapsible behavior of the sidebar (offcanvas, icon, none).
+ * @param {React.ReactNode} children - The content to be rendered inside the sidebar.
+ *
+ * @example
+ * <Sidebar side="left" variant="sidebar" collapsible="offcanvas">
+ *   <SidebarContent>Content</SidebarContent>
+ * </Sidebar>
+ */
 const Sidebar = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
@@ -255,6 +287,17 @@ const Sidebar = React.forwardRef<
 )
 Sidebar.displayName = "Sidebar"
 
+/**
+ * SidebarTrigger component.
+ *
+ * This component provides a button to toggle the sidebar.
+ *
+ * @param {Function} onClick - Callback function when the button is clicked.
+ * @param {string} className - Additional Tailwind CSS classes for the button.
+ *
+ * @example
+ * <SidebarTrigger className="custom-class" onClick={() => console.log('Clicked')} />
+ */
 const SidebarTrigger = React.forwardRef<
   React.ElementRef<typeof Button>,
   React.ComponentProps<typeof Button>
@@ -281,6 +324,17 @@ const SidebarTrigger = React.forwardRef<
 });
 SidebarTrigger.displayName = "SidebarTrigger";
 
+/**
+ * SidebarRail component.
+ *
+ * This component provides a rail for toggling the sidebar.
+ *
+ * @param {Function} onClick - Callback function when the rail is clicked.
+ * @param {string} className - Additional Tailwind CSS classes for the rail.
+ *
+ * @example
+ * <SidebarRail className="custom-class" onClick={() => console.log('Clicked')} />
+ */
 const SidebarRail = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<"button">
@@ -310,6 +364,19 @@ const SidebarRail = React.forwardRef<
 })
 SidebarRail.displayName = "SidebarRail"
 
+/**
+ * SidebarInset component.
+ *
+ * This component provides an inset container for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the container.
+ * @param {React.ReactNode} children - The content to be rendered inside the container.
+ *
+ * @example
+ * <SidebarInset className="custom-class">
+ *   <div>Content</div>
+ * </SidebarInset>
+ */
 const SidebarInset = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"main">
@@ -328,6 +395,17 @@ const SidebarInset = React.forwardRef<
 })
 SidebarInset.displayName = "SidebarInset"
 
+/**
+ * SidebarInput component.
+ *
+ * This component provides an input field for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the input.
+ * @param {React.ReactNode} children - The content to be rendered inside the input.
+ *
+ * @example
+ * <SidebarInput className="custom-class" placeholder="Search..." />
+ */
 const SidebarInput = React.forwardRef<
   React.ElementRef<typeof Input>,
   React.ComponentProps<typeof Input>
@@ -346,6 +424,19 @@ const SidebarInput = React.forwardRef<
 })
 SidebarInput.displayName = "SidebarInput"
 
+/**
+ * SidebarHeader component.
+ *
+ * This component provides a header for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the header.
+ * @param {React.ReactNode} children - The content to be rendered inside the header.
+ *
+ * @example
+ * <SidebarHeader className="custom-class">
+ *   <div>Header Content</div>
+ * </SidebarHeader>
+ */
 const SidebarHeader = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
@@ -361,6 +452,19 @@ const SidebarHeader = React.forwardRef<
 })
 SidebarHeader.displayName = "SidebarHeader"
 
+/**
+ * SidebarFooter component.
+ *
+ * This component provides a footer for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the footer.
+ * @param {React.ReactNode} children - The content to be rendered inside the footer.
+ *
+ * @example
+ * <SidebarFooter className="custom-class">
+ *   <div>Footer Content</div>
+ * </SidebarFooter>
+ */
 const SidebarFooter = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
@@ -376,6 +480,16 @@ const SidebarFooter = React.forwardRef<
 })
 SidebarFooter.displayName = "SidebarFooter"
 
+/**
+ * SidebarSeparator component.
+ *
+ * This component provides a separator for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the separator.
+ *
+ * @example
+ * <SidebarSeparator className="custom-class" />
+ */
 const SidebarSeparator = React.forwardRef<
   React.ElementRef<typeof Separator>,
   React.ComponentProps<typeof Separator>
@@ -391,6 +505,19 @@ const SidebarSeparator = React.forwardRef<
 })
 SidebarSeparator.displayName = "SidebarSeparator"
 
+/**
+ * SidebarContent component.
+ *
+ * This component provides content for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the content.
+ * @param {React.ReactNode} children - The content to be rendered inside the content.
+ *
+ * @example
+ * <SidebarContent className="custom-class">
+ *   <div>Content</div>
+ * </SidebarContent>
+ */
 const SidebarContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
@@ -409,6 +536,19 @@ const SidebarContent = React.forwardRef<
 })
 SidebarContent.displayName = "SidebarContent"
 
+/**
+ * SidebarGroup component.
+ *
+ * This component provides a group container for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the group.
+ * @param {React.ReactNode} children - The content to be rendered inside the group.
+ *
+ * @example
+ * <SidebarGroup className="custom-class">
+ *   <div>Group Content</div>
+ * </SidebarGroup>
+ */
 const SidebarGroup = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
@@ -424,6 +564,20 @@ const SidebarGroup = React.forwardRef<
 })
 SidebarGroup.displayName = "SidebarGroup"
 
+/**
+ * SidebarGroupLabel component.
+ *
+ * This component provides a label for the sidebar group.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the label.
+ * @param {React.ReactNode} children - The content to be rendered inside the label.
+ * @param {boolean} asChild - Whether to render the label as a child component.
+ *
+ * @example
+ * <SidebarGroupLabel className="custom-class" asChild={true}>
+ *   <div>Label Content</div>
+ * </SidebarGroupLabel>
+ */
 const SidebarGroupLabel = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & { asChild?: boolean }
@@ -445,6 +599,20 @@ const SidebarGroupLabel = React.forwardRef<
 })
 SidebarGroupLabel.displayName = "SidebarGroupLabel"
 
+/**
+ * SidebarGroupAction component.
+ *
+ * This component provides an action button for the sidebar group.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the action button.
+ * @param {React.ReactNode} children - The content to be rendered inside the action button.
+ * @param {boolean} asChild - Whether to render the action button as a child component.
+ *
+ * @example
+ * <SidebarGroupAction className="custom-class" asChild={true}>
+ *   <div>Action Content</div>
+ * </SidebarGroupAction>
+ */
 const SidebarGroupAction = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<"button"> & { asChild?: boolean }
@@ -468,6 +636,19 @@ const SidebarGroupAction = React.forwardRef<
 })
 SidebarGroupAction.displayName = "SidebarGroupAction"
 
+/**
+ * SidebarGroupContent component.
+ *
+ * This component provides content for the sidebar group.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the content.
+ * @param {React.ReactNode} children - The content to be rendered inside the content.
+ *
+ * @example
+ * <SidebarGroupContent className="custom-class">
+ *   <div>Group Content</div>
+ * </SidebarGroupContent>
+ */
 const SidebarGroupContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
@@ -481,6 +662,20 @@ const SidebarGroupContent = React.forwardRef<
 ))
 SidebarGroupContent.displayName = "SidebarGroupContent"
 
+/**
+ * SidebarMenu component.
+ *
+ * This component provides a menu for the sidebar.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the menu.
+ * @param {React.ReactNode} children - The content to be rendered inside the menu.
+ *
+ * @example
+ * <SidebarMenu className="custom-class">
+ *   <SidebarMenuItem>Item 1</SidebarMenuItem>
+ *   <SidebarMenuItem>Item 2</SidebarMenuItem>
+ * </SidebarMenu>
+ */
 const SidebarMenu = React.forwardRef<
   HTMLUListElement,
   React.ComponentProps<"ul">
@@ -494,6 +689,19 @@ const SidebarMenu = React.forwardRef<
 ))
 SidebarMenu.displayName = "SidebarMenu"
 
+/**
+ * SidebarMenuItem component.
+ *
+ * This component provides a menu item for the sidebar menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the menu item.
+ * @param {React.ReactNode} children - The content to be rendered inside the menu item.
+ *
+ * @example
+ * <SidebarMenuItem className="custom-class">
+ *   <div>Item Content</div>
+ * </SidebarMenuItem>
+ */
 const SidebarMenuItem = React.forwardRef<
   HTMLLIElement,
   React.ComponentProps<"li">
@@ -529,6 +737,22 @@ const sidebarMenuButtonVariants = cva(
   }
 )
 
+/**
+ * SidebarMenuButton component.
+ *
+ * This component provides a button for the sidebar menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the button.
+ * @param {React.ReactNode} children - The content to be rendered inside the button.
+ * @param {boolean} asChild - Whether to render the button as a child component.
+ * @param {boolean} isActive - Whether the button is active.
+ * @param {string|object} tooltip - Tooltip content for the button.
+ *
+ * @example
+ * <SidebarMenuButton className="custom-class" isActive={true} tooltip="Tooltip Content">
+ *   <div>Button Content</div>
+ * </SidebarMenuButton>
+ */
 const SidebarMenuButton = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<"button"> & {
@@ -588,6 +812,21 @@ const SidebarMenuButton = React.forwardRef<
 )
 SidebarMenuButton.displayName = "SidebarMenuButton"
 
+/**
+ * SidebarMenuAction component.
+ *
+ * This component provides an action button for the sidebar menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the action button.
+ * @param {React.ReactNode} children - The content to be rendered inside the action button.
+ * @param {boolean} asChild - Whether to render the action button as a child component.
+ * @param {boolean} showOnHover - Whether to show the action button on hover.
+ *
+ * @example
+ * <SidebarMenuAction className="custom-class" showOnHover={true}>
+ *   <div>Action Content</div>
+ * </SidebarMenuAction>
+ */
 const SidebarMenuAction = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<"button"> & {
@@ -619,6 +858,19 @@ const SidebarMenuAction = React.forwardRef<
 })
 SidebarMenuAction.displayName = "SidebarMenuAction"
 
+/**
+ * SidebarMenuBadge component.
+ *
+ * This component provides a badge for the sidebar menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the badge.
+ * @param {React.ReactNode} children - The content to be rendered inside the badge.
+ *
+ * @example
+ * <SidebarMenuBadge className="custom-class">
+ *   <div>Badge Content</div>
+ * </SidebarMenuBadge>
+ */
 const SidebarMenuBadge = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
@@ -640,6 +892,17 @@ const SidebarMenuBadge = React.forwardRef<
 ))
 SidebarMenuBadge.displayName = "SidebarMenuBadge"
 
+/**
+ * SidebarMenuSkeleton component.
+ *
+ * This component provides a skeleton loader for the sidebar menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the skeleton loader.
+ * @param {boolean} showIcon - Whether to show an icon in the skeleton loader.
+ *
+ * @example
+ * <SidebarMenuSkeleton className="custom-class" showIcon={true} />
+ */
 const SidebarMenuSkeleton = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
@@ -678,6 +941,20 @@ const SidebarMenuSkeleton = React.forwardRef<
 })
 SidebarMenuSkeleton.displayName = "SidebarMenuSkeleton"
 
+/**
+ * SidebarMenuSub component.
+ *
+ * This component provides a sub-menu for the sidebar menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the sub-menu.
+ * @param {React.ReactNode} children - The content to be rendered inside the sub-menu.
+ *
+ * @example
+ * <SidebarMenuSub className="custom-class">
+ *   <SidebarMenuSubItem>Sub Item 1</SidebarMenuSubItem>
+ *   <SidebarMenuSubItem>Sub Item 2</SidebarMenuSubItem>
+ * </SidebarMenuSub>
+ */
 const SidebarMenuSub = React.forwardRef<
   HTMLUListElement,
   React.ComponentProps<"ul">
@@ -695,12 +972,41 @@ const SidebarMenuSub = React.forwardRef<
 ))
 SidebarMenuSub.displayName = "SidebarMenuSub"
 
+/**
+ * SidebarMenuSubItem component.
+ *
+ * This component provides a sub-menu item for the sidebar menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the sub-menu item.
+ * @param {React.ReactNode} children - The content to be rendered inside the sub-menu item.
+ *
+ * @example
+ * <SidebarMenuSubItem className="custom-class">
+ *   <div>Sub Item Content</div>
+ * </SidebarMenuSubItem>
+ */
 const SidebarMenuSubItem = React.forwardRef<
   HTMLLIElement,
   React.ComponentProps<"li">
 >(({ ...props }, ref) => <li ref={ref} {...props} />)
 SidebarMenuSubItem.displayName = "SidebarMenuSubItem"
 
+/**
+ * SidebarMenuSubButton component.
+ *
+ * This component provides a button for the sidebar sub-menu.
+ *
+ * @param {string} className - Additional Tailwind CSS classes for the button.
+ * @param {React.ReactNode} children - The content to be rendered inside the button.
+ * @param {boolean} asChild - Whether to render the button as a child component.
+ * @param {boolean} isActive - Whether the button is active.
+ * @param {string} size - The size of the button (sm, md).
+ *
+ * @example
+ * <SidebarMenuSubButton className="custom-class" isActive={true} size="md">
+ *   <div>Button Content</div>
+ * </SidebarMenuSubButton>
+ */
 const SidebarMenuSubButton = React.forwardRef<
   HTMLAnchorElement,
   React.ComponentProps<"a"> & {

--- a/libs/shadcnui/src/components/ui/layout/sidebar/sidebar.tsx
+++ b/libs/shadcnui/src/components/ui/layout/sidebar/sidebar.tsx
@@ -173,16 +173,6 @@ SidebarProvider.displayName = "SidebarProvider"
  *
  * This component provides a sidebar with various configurations, including
  * collapsible behavior and different variants.
- *
- * @param {string} side - The side of the screen where the sidebar appears (left or right).
- * @param {string} variant - The variant of the sidebar (sidebar, floating, inset).
- * @param {string} collapsible - The collapsible behavior of the sidebar (offcanvas, icon, none).
- * @param {React.ReactNode} children - The content to be rendered inside the sidebar.
- *
- * @example
- * <Sidebar side="left" variant="sidebar" collapsible="offcanvas">
- *   <SidebarContent>Content</SidebarContent>
- * </Sidebar>
  */
 const Sidebar = React.forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
Fixes #141

Add Storybook stories and JSDoc comments for `libs/shadcnui/src/components/ui/layout` components.

* **AspectRatio Component**: Add Storybook stories in `aspect-ratio.stories.tsx` and JSDoc comments in `aspect-ratio.tsx`.
* **Collapsible Component**: Add Storybook stories in `collapsible.stories.tsx` and JSDoc comments in `collapsible.tsx`.
* **Resizable Component**: Add Storybook stories in `resizable.stories.tsx` and JSDoc comments in `resizable.tsx`.
* **ScrollArea Component**: Add Storybook stories in `scroll-area.stories.tsx` and JSDoc comments in `scroll-area.tsx`.
* **Separator Component**: Add Storybook stories in `separator.stories.tsx` and JSDoc comments in `separator.tsx`.
* **Sheet Component**: Add Storybook stories in `sheet.stories.tsx` and JSDoc comments in `sheet.tsx`.
* **Sidebar Component**: Add Storybook stories in `sidebar.stories.tsx` and JSDoc comments in `sidebar.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/145?shareId=1200e6cc-ba1a-49de-bf9f-1ef331dc613a).