### PR TITLE
Reusable StatsBlock component for the landing page library

### DIFF
--- a/docs/reusable-react-components.md
+++ b/docs/reusable-react-components.md
@@ -12,6 +12,8 @@
    6. [Ensure Accessibility](#6-ensure-accessibility)
    7. [Abstract Styles for Reuse](#7-abstract-styles-for-reuse)
 3. [Summary Checklist](#summary-checklist)
+4. [StatItem Component](#statitem-component)
+5. [StatsBlock Component](#statsblock-component)
 
 ## Principles of Reusable Component Design
 
@@ -240,3 +242,76 @@ export const AppSidebar = ({ ...props }) => <div {...props} />;
 ```
 
 By following these best practices, you can effectively use the new `shell` library components to build a maintainable, scalable, and high-quality React application.
+
+## StatItem Component
+
+The `StatItem` component is designed to encapsulate individual statistic elements, including an icon, value, title, and description. It is flexible and reusable across different parts of the application.
+
+### Props
+
+- `icon`: ReactNode - The icon to display.
+- `value`: string | number - The value of the statistic.
+- `title`: string - The title of the statistic.
+- `description`: string - A brief description of the statistic.
+
+### Usage
+
+```tsx
+import { StatItem } from '@rwoc/shadcnui-blocks';
+import { FaUser } from 'react-icons/fa';
+
+const Example = () => (
+  <StatItem
+    icon={<FaUser className="text-primary" />}
+    value="1,234"
+    title="Users"
+    description="Number of active users"
+  />
+);
+```
+
+## StatsBlock Component
+
+The `StatsBlock` component aggregates multiple `StatItem` components into a cohesive block. It uses a flexbox layout with wrapping for responsiveness and includes accessibility features.
+
+### Props
+
+- `stats`: StatItemProps[] - An array of statistic data to dynamically generate `StatItem` components.
+
+### Usage
+
+```tsx
+import { StatsBlock } from '@rwoc/shadcnui-blocks';
+import { FaUser, FaChartLine, FaDollarSign } from 'react-icons/fa';
+
+const stats = [
+  {
+    icon: <FaUser className="text-primary" />,
+    value: '1,234',
+    title: 'Users',
+    description: 'Number of active users',
+  },
+  {
+    icon: <FaChartLine className="text-primary" />,
+    value: '567',
+    title: 'Sessions',
+    description: 'Number of sessions today',
+  },
+  {
+    icon: <FaDollarSign className="text-primary" />,
+    value: '$12,345',
+    title: 'Revenue',
+    description: 'Total revenue this month',
+  },
+];
+
+const Example = () => <StatsBlock stats={stats} />;
+```
+
+### Empty State
+
+The `StatsBlock` component displays a placeholder message or icon when there is no data to display.
+
+```tsx
+const ExampleEmptyState = () => <StatsBlock stats={[]} />;
+```

--- a/libs/shadcnui-blocks/README.md
+++ b/libs/shadcnui-blocks/README.md
@@ -5,3 +5,68 @@ This library was generated with [Nx](https://nx.dev).
 ## Running unit tests
 
 Run `nx test shadcnui-blocks` to execute the unit tests via [Vitest](https://vitest.dev/).
+
+## Components
+
+### StatItem
+
+The `StatItem` component encapsulates individual statistic elements, including an icon, value, title, and description.
+
+#### Props
+
+- `icon`: ReactNode - The icon to display.
+- `value`: string | number - The value of the statistic.
+- `title`: string - The title of the statistic.
+- `description`: string - The description of the statistic.
+
+#### Usage
+
+```tsx
+import { StatItem } from '@rwoc/shadcnui-blocks';
+import { FaUser } from 'react-icons/fa';
+
+<StatItem
+  icon={<FaUser className="text-primary" />}
+  value="1,234"
+  title="Users"
+  description="Number of active users"
+/>
+```
+
+### StatsBlock
+
+The `StatsBlock` component aggregates multiple `StatItem` components into a cohesive block.
+
+#### Props
+
+- `stats`: StatItemProps[] - An array of statistic data to dynamically generate `StatItem` components.
+
+#### Usage
+
+```tsx
+import { StatsBlock } from '@rwoc/shadcnui-blocks';
+import { FaUser, FaChartLine, FaDollarSign } from 'react-icons/fa';
+
+const stats = [
+  {
+    icon: <FaUser className="text-primary" />,
+    value: '1,234',
+    title: 'Users',
+    description: 'Number of active users',
+  },
+  {
+    icon: <FaChartLine className="text-primary" />,
+    value: '567',
+    title: 'Sessions',
+    description: 'Number of sessions today',
+  },
+  {
+    icon: <FaDollarSign className="text-primary" />,
+    value: '$12,345',
+    title: 'Revenue',
+    description: 'Total revenue this month',
+  },
+];
+
+<StatsBlock stats={stats} />
+```

--- a/libs/shadcnui-blocks/src/lib/components/StatItem.stories.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/StatItem.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatItem, StatItemProps } from './StatItem';
+import { FaUser, FaChartLine, FaDollarSign } from 'react-icons/fa';
+
+const meta: Meta<typeof StatItem> = {
+  title: 'Shadcnui Blocks/StatItem',
+  component: StatItem,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: { control: 'text' },
+    value: { control: 'text' },
+    title: { control: 'text' },
+    description: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatItem>;
+
+/**
+ * Default usage of the StatItem component.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args: StatItemProps) => <StatItem {...args} />,
+  args: {
+    icon: <FaUser className="text-primary" />,
+    value: '1,234',
+    title: 'Users',
+    description: 'Number of active users',
+  },
+};
+
+/**
+ * Custom usage of the StatItem component with a different icon and value.
+ */
+export const Custom: Story = {
+  name: 'Custom',
+  render: (args: StatItemProps) => <StatItem {...args} />,
+  args: {
+    icon: <FaChartLine className="text-primary" />,
+    value: '567',
+    title: 'Sessions',
+    description: 'Number of sessions today',
+  },
+};
+
+/**
+ * Another custom usage of the StatItem component with a different icon and value.
+ */
+export const Revenue: Story = {
+  name: 'Revenue',
+  render: (args: StatItemProps) => <StatItem {...args} />,
+  args: {
+    icon: <FaDollarSign className="text-primary" />,
+    value: '$12,345',
+    title: 'Revenue',
+    description: 'Total revenue this month',
+  },
+};

--- a/libs/shadcnui-blocks/src/lib/components/StatItem.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/StatItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface StatItemProps {
+  icon: React.ReactNode;
+  value: string | number;
+  title: string;
+  description: string;
+}
+
+const StatItem: React.FC<StatItemProps> = ({ icon, value, title, description }) => {
+  return (
+    <div className="flex items-center space-x-4 p-4 bg-white rounded-lg shadow-md" role="region" aria-labelledby={`${title}-stat`}>
+      <div className="flex-shrink-0">
+        {icon}
+      </div>
+      <div>
+        <h2 id={`${title}-stat`} className="text-lg font-medium text-gray-900">{title}</h2>
+        <p className="text-2xl font-bold text-gray-900">{value}</p>
+        <p className="text-sm text-gray-500">{description}</p>
+      </div>
+    </div>
+  );
+};
+
+export { StatItem, StatItemProps };

--- a/libs/shadcnui-blocks/src/lib/components/StatsBlock.stories.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/StatsBlock.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StatsBlock, StatsBlockProps } from './StatsBlock';
+import { FaUser, FaChartLine, FaDollarSign } from 'react-icons/fa';
+
+const meta: Meta<typeof StatsBlock> = {
+  title: 'Shadcnui Blocks/StatsBlock',
+  component: StatsBlock,
+  tags: ['autodocs'],
+  argTypes: {
+    stats: { control: 'object' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatsBlock>;
+
+/**
+ * Default usage of the StatsBlock component.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args: StatsBlockProps) => <StatsBlock {...args} />,
+  args: {
+    stats: [
+      {
+        icon: <FaUser className="text-primary" />,
+        value: '1,234',
+        title: 'Users',
+        description: 'Number of active users',
+      },
+      {
+        icon: <FaChartLine className="text-primary" />,
+        value: '567',
+        title: 'Sessions',
+        description: 'Number of sessions today',
+      },
+      {
+        icon: <FaDollarSign className="text-primary" />,
+        value: '$12,345',
+        title: 'Revenue',
+        description: 'Total revenue this month',
+      },
+    ],
+  },
+};
+
+/**
+ * Custom usage of the StatsBlock component with different data.
+ */
+export const Custom: Story = {
+  name: 'Custom',
+  render: (args: StatsBlockProps) => <StatsBlock {...args} />,
+  args: {
+    stats: [
+      {
+        icon: <FaUser className="text-primary" />,
+        value: '2,345',
+        title: 'New Users',
+        description: 'Number of new users this week',
+      },
+      {
+        icon: <FaChartLine className="text-primary" />,
+        value: '789',
+        title: 'Page Views',
+        description: 'Number of page views today',
+      },
+      {
+        icon: <FaDollarSign className="text-primary" />,
+        value: '$23,456',
+        title: 'Monthly Revenue',
+        description: 'Total revenue this month',
+      },
+    ],
+  },
+};
+
+/**
+ * Empty state usage of the StatsBlock component.
+ */
+export const EmptyState: Story = {
+  name: 'Empty State',
+  render: (args: StatsBlockProps) => <StatsBlock {...args} />,
+  args: {
+    stats: [],
+  },
+};

--- a/libs/shadcnui-blocks/src/lib/components/StatsBlock.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/StatsBlock.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { StatItem, StatItemProps } from './StatItem';
+
+interface StatsBlockProps {
+  stats: StatItemProps[];
+}
+
+const StatsBlock: React.FC<StatsBlockProps> = ({ stats }) => {
+  if (stats.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-4 bg-gray-100 rounded-lg shadow-md" role="region" aria-label="No data available">
+        <p className="text-lg font-medium text-gray-900">No data available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap justify-center items-center gap-4">
+      {stats.map((stat, index) => (
+        <StatItem key={index} {...stat} />
+      ))}
+    </div>
+  );
+};
+
+export { StatsBlock, StatsBlockProps };

--- a/libs/shadcnui-blocks/src/lib/components/index.ts
+++ b/libs/shadcnui-blocks/src/lib/components/index.ts
@@ -10,3 +10,5 @@ export * from './steps/index';
 export * from './tagline/index';
 export * from './target-achievement-chart/index';
 export * from './testimonials/index';
+export * from './StatItem';
+export * from './StatsBlock';


### PR DESCRIPTION
Fixes #115

Add `StatItem` and `StatsBlock` components with responsive design and accessibility features.

* **StatItem Component:**
  - Implement `StatItem` component in `libs/shadcnui-blocks/src/lib/components/StatItem.tsx` to accept `icon`, `value`, `title`, and `description` as props.
  - Use Tailwind CSS for styling and ensure accessibility with ARIA attributes.
  - Export `StatItem` component.

* **StatsBlock Component:**
  - Implement `StatsBlock` component in `libs/shadcnui-blocks/src/lib/components/StatsBlock.tsx` to accept an array of statistic data as props.
  - Use flexbox layout with wrapping for responsiveness and include accessibility features.
  - Display a placeholder message or icon when there is no data to display.
  - Export `StatsBlock` component.

* **Exports:**
  - Modify `libs/shadcnui-blocks/src/lib/components/index.ts` to export `StatItem` and `StatsBlock` components.

* **Storybook Stories:**
  - Add Storybook stories for `StatItem` component in `libs/shadcnui-blocks/src/lib/components/StatItem.stories.tsx` demonstrating default usage and customization.
  - Add Storybook stories for `StatsBlock` component in `libs/shadcnui-blocks/src/lib/components/StatsBlock.stories.tsx` demonstrating default usage, customization, and empty state.

* **Documentation:**
  - Update `docs/reusable-react-components.md` to include documentation for `StatItem` and `StatsBlock` components, including props and usage instructions.
  - Update `libs/shadcnui-blocks/README.md` to include `StatItem` and `StatsBlock` components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/156?shareId=4e0500a7-a89d-416b-864b-a505722bfa1a).