### PR TITLE
Add new CTA Section component to landing library

### DIFF
--- a/apps/demo/src/app/pages/landing/Landing.tsx
+++ b/apps/demo/src/app/pages/landing/Landing.tsx
@@ -166,7 +166,7 @@ export const LandingPage: FC = () => {
         data-testid="features-section"
       />
       <CTASection
-        variant="light" // Replacing DemoSection (light background by default)
+        variant="light" // 
         title="Experience It Yourself"
         description="Try our live demo to see how effortlessly you can set up and scale your React project with React Weapons of Choice."
         buttonText="Try the Demo"
@@ -174,7 +174,7 @@ export const LandingPage: FC = () => {
         data-testid="demo-section"
       />
       <CTASection
-        variant="dark" // Replacing CommunitySection with a darker background
+        variant="dark" 
         title="Join the Community"
         description="React Weapons of Choice is built by developers, for developers. Contribute, discuss, and shape the future of the project."
         buttonText="Contribute on GitHub"

--- a/apps/demo/src/app/pages/landing/Landing.tsx
+++ b/apps/demo/src/app/pages/landing/Landing.tsx
@@ -15,8 +15,7 @@ import logoSrc from '../../../assets/images/rwoc-logo.png';
 
 import {
   AboutSection,
-  CommunitySection,
-  DemoSection,
+  CTASection,
   FeaturesSection,
   Footer,
   GetStartedSection,
@@ -166,14 +165,16 @@ export const LandingPage: FC = () => {
         ]}
         data-testid="features-section"
       />
-      <DemoSection
+      <CTASection
+        variant="light" // Replacing DemoSection (light background by default)
         title="Experience It Yourself"
         description="Try our live demo to see how effortlessly you can set up and scale your React project with React Weapons of Choice."
         buttonText="Try the Demo"
         buttonAction={() => navigate('/home')}
         data-testid="demo-section"
       />
-      <CommunitySection
+      <CTASection
+        variant="dark" // Replacing CommunitySection with a darker background
         title="Join the Community"
         description="React Weapons of Choice is built by developers, for developers. Contribute, discuss, and shape the future of the project."
         buttonText="Contribute on GitHub"
@@ -183,7 +184,6 @@ export const LandingPage: FC = () => {
             '_blank'
           )
         }
-        isDarkBackground={true} // Pass the new prop
         data-testid="community-section"
       />
       <GetStartedSection

--- a/libs/landing/src/lib/components/CTASection.stories.tsx
+++ b/libs/landing/src/lib/components/CTASection.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CTASection } from './CTASection';
+import { action } from '@storybook/addon-actions';
+
+const meta: Meta<typeof CTASection> = {
+  title: 'Landing/CTASection',
+  component: CTASection,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      name: 'Title',
+      control: 'text',
+      description: 'The title of the CTA section',
+    },
+    description: {
+      name: 'Description',
+      control: 'text',
+      description: 'The description of the CTA section',
+    },
+    buttonText: {
+      name: 'Button Text',
+      control: 'text',
+      description: 'The text displayed on the button',
+    },
+    buttonAction: {
+      name: 'Button Action',
+      action: 'button-click',
+      description: 'The action performed when the button is clicked',
+    },
+    variant: {
+      name: 'Variant',
+      control: 'select',
+      options: ['light', 'dark'],
+      description: 'The visual variant for the section\'s background and text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CTASection>;
+
+/**
+ * Default story for the CTASection component.
+ * Demonstrates the component with default props.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => <CTASection {...args} />,
+  args: {
+    title: 'Experience It Yourself',
+    description: 'Try our live demo to see how effortlessly you can set up and scale your React project with React Weapons of Choice.',
+    buttonText: 'Try the Demo',
+    buttonAction: action('button-click'),
+    variant: 'light',
+  },
+};
+
+/**
+ * Story for the CTASection component with different prop combinations.
+ * Shows the component with a dark background and different text.
+ */
+export const WithDifferentProps: Story = {
+  name: 'With Different Props',
+  render: (args) => <CTASection {...args} />,
+  args: {
+    title: 'Join the Community',
+    description: 'React Weapons of Choice is built by developers, for developers. Contribute, discuss, and shape the future of the project.',
+    buttonText: 'Contribute on GitHub',
+    buttonAction: action('button-click'),
+    variant: 'dark',
+  },
+};
+
+/**
+ * Story for the CTASection component with edge cases.
+ * Demonstrates the component with empty strings for title, description, and buttonText.
+ */
+export const WithEdgeCases: Story = {
+  name: 'With Edge Cases',
+  render: (args) => <CTASection {...args} />,
+  args: {
+    title: '',
+    description: '',
+    buttonText: '',
+    buttonAction: action('button-click'),
+    variant: 'light',
+  },
+};

--- a/libs/landing/src/lib/components/CTASection.tsx
+++ b/libs/landing/src/lib/components/CTASection.tsx
@@ -42,17 +42,17 @@ export const CTASection: FC<CTASectionProps> = ({
   const baseParagraphClasses = 'text-xl mb-8 max-w-2xl mx-auto';
   
   // Default styles for the 'light' variant
-  let sectionClasses = 'bg-light text-primary';
+  let sectionClasses = 'bg-background text-primary';
   let headingClasses = `${baseHeadingClasses} text-primary`;
   let paragraphClasses = `${baseParagraphClasses} text-primary`;
   let buttonClasses = 'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground';
 
   // Override styles if using the 'dark' variant
   if (variant === 'dark') {
-    sectionClasses = 'bg-dark text-primary-foreground';
+    sectionClasses = 'bg-primary text-primary-foreground';
     headingClasses = `${baseHeadingClasses} text-primary-foreground`;
     paragraphClasses = `${baseParagraphClasses} text-primary-foreground`;
-    buttonClasses = 'bg-primary text-primary-foreground hover:bg-primary-foreground/90 hover:text-primary';
+    buttonClasses = 'bg-primary-foreground text-primary hover:bg-primary-foreground/90 hover:text-primary';
   }
 
   return (

--- a/libs/landing/src/lib/components/CTASection.tsx
+++ b/libs/landing/src/lib/components/CTASection.tsx
@@ -1,0 +1,72 @@
+import { FC } from 'react';
+import { Button } from '@rwoc/shadcnui';
+
+/**
+ * Possible color variants for the CTA section.
+ * - 'light' gives a lighter background and primary text
+ * - 'dark' gives a darker background and foreground text
+ */
+type CTASectionVariant = 'light' | 'dark';
+
+interface CTASectionProps {
+  /** The title to display in the section. */
+  title: string;
+  /** The description text to display in the section. */
+  description: string;
+  /** The text to display on the button. */
+  buttonText: string;
+  /** The action to perform when the button is clicked. */
+  buttonAction: () => void;
+  /**
+   * The visual variant for the section's background and text.
+   * Defaults to 'light'.
+   */
+  variant?: CTASectionVariant;
+}
+
+/**
+ * A reusable CTA (Call-To-Action) section component with two variants:
+ * 'light' and 'dark'. This helps break up a single-color landing page
+ * into distinct sections.
+ */
+export const CTASection: FC<CTASectionProps> = ({
+  title,
+  description,
+  buttonText,
+  buttonAction,
+  variant = 'light',
+}) => {
+  // Shared base classes
+  const baseSectionClasses = 'text-center py-20 w-full';
+  const baseHeadingClasses = 'text-4xl font-bold mb-6';
+  const baseParagraphClasses = 'text-xl mb-8 max-w-2xl mx-auto';
+  
+  // Default styles for the 'light' variant
+  let sectionClasses = 'bg-light text-primary';
+  let headingClasses = `${baseHeadingClasses} text-primary`;
+  let paragraphClasses = `${baseParagraphClasses} text-primary`;
+  let buttonClasses = 'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground';
+
+  // Override styles if using the 'dark' variant
+  if (variant === 'dark') {
+    sectionClasses = 'bg-dark text-primary-foreground';
+    headingClasses = `${baseHeadingClasses} text-primary-foreground`;
+    paragraphClasses = `${baseParagraphClasses} text-primary-foreground`;
+    buttonClasses = 'bg-primary text-primary-foreground hover:bg-primary-foreground/90 hover:text-primary';
+  }
+
+  return (
+    <section className={`${baseSectionClasses} ${sectionClasses}`}>
+      <h2 className={headingClasses}>{title}</h2>
+      <p className={paragraphClasses}>{description}</p>
+      <Button
+        size="lg"
+        onClick={buttonAction}
+        className={buttonClasses}
+        aria-label={buttonText}
+      >
+        {buttonText}
+      </Button>
+    </section>
+  );
+};

--- a/libs/landing/src/lib/components/index.ts
+++ b/libs/landing/src/lib/components/index.ts
@@ -1,5 +1,6 @@
 export * from './AboutSection';
 export * from './CommunitySection';
+export * from './CTASection';
 export * from './DemoSection';
 export * from './features-section';
 export * from './HeroSection';


### PR DESCRIPTION
Fixes #157

Add new CTASection component to replace CommunitySection and DemoSection components.

* **CTASection Component**: Implement the new `CTASection` component in `libs/landing/src/lib/components/CTASection.tsx` with 'light' and 'dark' variants.
* **Storybook Stories**: Add Storybook stories for the `CTASection` component in `libs/landing/src/lib/components/CTASection.stories.tsx` to cover possible use cases and include JSDoc comments.
* **Landing Page Update**: Replace `CommunitySection` and `DemoSection` components with `CTASection` component in `apps/demo/src/app/pages/landing/Landing.tsx` and update the props accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/158?shareId=3113df28-8aa6-4c70-b474-d331fa4420c0).