### PR TITLE
Prevent empty commits in Lighthouse badge update workflow

### DIFF
--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -50,7 +50,11 @@ jobs:
       - name: Commit and push changes
         run: |
           git add ./lighthouse-badges/*
-          git commit -m "Update Lighthouse badges"
-          git push origin main
+          if git diff-index --quiet HEAD; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update Lighthouse badges"
+            git push origin main
+          fi
         env:
           GITHUB_TOKEN: ${{ steps.generate-app-token.outputs.token }}


### PR DESCRIPTION
Ensure the workflow checks for changes before committing and pushing updates to the Lighthouse badges, preventing unnecessary empty commits.