### PR TITLE
Update Monorail Updater exit code and log commit author in workflow

### DIFF
--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -32,8 +32,9 @@ jobs:
           AUTHOR=$(git log -1 --pretty=format:'%an')
           if [ "$AUTHOR" = "Monorail Updater" ]; then
             echo "Commit made by Monorail Updater, exiting..."
-            exit 0
+            exit 1
           fi
+        continue-on-error: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -36,6 +36,12 @@ jobs:
           fi
         continue-on-error: true
 
+      - name: Log commit author
+        if: success()
+        run: |
+          AUTHOR=$(git log -1 --pretty=format:'%an')
+          echo "Commit author: $AUTHOR"
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Change the exit code for the Monorail Updater check to indicate failure and add logging for the commit author in the Lighthouse audit workflow.