### PR TITLE
Add author check to prevent actions from Monorail Updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    env:
+      AUTHOR_NAME: ''
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -26,31 +28,29 @@ jobs:
         id: check-author
         run: |
           AUTHOR=$(git log -1 --pretty=format:'%an')
-          echo "author=$AUTHOR" >> $GITHUB_ENV
+          echo "AUTHOR_NAME=$AUTHOR" >> $GITHUB_ENV
           if [ "$AUTHOR" = "Monorail Updater" ]; then
             echo "Commit author is Monorail Updater. Exiting..."
             exit 0
           fi
 
-      # Exit if commit author is Monorail Updater
-      - name: Exit if commit author is Monorail Updater
-        if: env.author == 'Monorail Updater'
-        run: exit 0
-
       # Set up Node.js with version 22
       - name: Setup Node.js
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       # Install pnpm
       - name: Install pnpm
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: pnpm/action-setup@v2
         with:
           version: 9.15.0
 
       # Cache pnpm dependencies using actions/cache@v4
       - name: Cache pnpm store
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: actions/cache@v4 
         with:
           path: ~/.pnpm-store
@@ -59,10 +59,12 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Prune pnpm store
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: pnpm store prune
 
       # Install dependencies
       - name: Install Dependencies
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           retry() {
             for i in {1..3}; do
@@ -76,10 +78,12 @@ jobs:
 
       # Install Playwright Browsers
       # - name: Install Playwright Browsers
+      #   if: env.AUTHOR_NAME != 'Monorail Updater'
       #   run: pnpm exec playwright install
 
       # Run Nx Affected Tasks
       - name: Run Nx Affected Tasks
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           pnpm exec nx affected -t lint --base=origin/main --head=HEAD --exclude=storybook-host,common-tailwind
           pnpm exec nx affected -t test --base=origin/main --head=HEAD --exclude=storybook-host,common-tailwind
@@ -87,14 +91,17 @@ jobs:
 
       # Start Application
       # - name: Start Application
+      #   if: env.AUTHOR_NAME != 'Monorail Updater'
       #   run: pnpm exec nx run riffroll:preview &
       #   env:
       #      CI: true
 
       # Wait for Application to be Ready
       # - name: Wait for Application to be Ready
+      #   if: env.AUTHOR_NAME != 'Monorail Updater'
       #   run: npx wait-on http://localhost:4300
 
       # Run E2E Tests
       # - name: Run E2E Tests
+      #   if: env.AUTHOR_NAME != 'Monorail Updater'
       #   run: pnpm exec nx affected -t e2e --base=origin/main --head=HEAD

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      AUTHOR_NAME: ''
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -22,28 +24,29 @@ jobs:
         id: check-author
         run: |
           AUTHOR=$(git log -1 --pretty=format:'%an')
-          echo "author=$AUTHOR" >> $GITHUB_ENV
+          echo "AUTHOR_NAME=$AUTHOR" >> $GITHUB_ENV
           if [ "$AUTHOR" = "Monorail Updater" ]; then
             echo "Commit author is Monorail Updater. Exiting..."
             exit 0
           fi
 
-      # Exit if commit author is Monorail Updater
-      - name: Exit if commit author is Monorail Updater
-        if: env.author == 'Monorail Updater'
-        run: exit 0
-
+      # Set up Node.js
       - name: Setup Node.js
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
 
+      # Install pnpm
       - name: Install pnpm
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: pnpm/action-setup@v2
         with:
           version: 9.15.0
 
+      # Cache pnpm dependencies
       - name: Cache pnpm dependencies
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
@@ -52,9 +55,11 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Prune pnpm store
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: pnpm store prune
 
       - name: Install dependencies
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           retry() {
             for i in {1..3}; do
@@ -67,12 +72,14 @@ jobs:
           retry pnpm install --frozen-lockfile
 
       - name: Build project
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           export BASE_URL='/react-weapons-of-choice/'
           export DEBUG='true'
           pnpm exec nx build demo --configuration=production --base=$BASE_URL
 
       - name: Build storybook
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           export BASE_URL='/react-weapons-of-choice/'
           export DEBUG='true'
@@ -80,6 +87,7 @@ jobs:
 
       # Upload artifact for deployment
       - name: Upload to GitHub Pages artifact
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: actions/upload-pages-artifact@v1
         with:
           path: dist/apps/demo # Path to your build output
@@ -94,4 +102,5 @@ jobs:
 
     steps:
       - name: Deploy to GitHub Pages
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: actions/deploy-pages@v1

--- a/.github/workflows/lighthouse-audit.yml
+++ b/.github/workflows/lighthouse-audit.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   update-badges:
     runs-on: ubuntu-latest
+    env:
+      AUTHOR_NAME: ''
     steps:
       # Generate GitHub App token
       - name: Generate GitHub App token
@@ -40,35 +42,34 @@ jobs:
         id: check-author
         run: |
           AUTHOR=$(git log -1 --pretty=format:'%an')
-          echo "author=$AUTHOR" >> $GITHUB_ENV
+          echo "AUTHOR_NAME=$AUTHOR" >> $GITHUB_ENV
           if [ "$AUTHOR" = "Monorail Updater" ]; then
             echo "Commit made by Monorail Updater, exiting..."
             exit 0
           fi
 
-      # Exit if commit author is Monorail Updater
-      - name: Exit if commit author is Monorail Updater
-        if: env.author == 'Monorail Updater'
-        run: exit 0
-
       # Set up Node.js
       - name: Set up Node.js
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: actions/setup-node@v4
         with:
           node-version: '22'
 
       # Set up pnpm
       - name: Set up pnpm
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         uses: pnpm/action-setup@v2
         with:
           version: 9.15.0
 
       # Install dependencies
       - name: Install dependencies
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: pnpm install
 
       # Create Lighthouse configuration file
       - name: Create Lighthouse configuration file
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           cat << 'EOF' > .lighthouse-config.json
           {
@@ -96,22 +97,26 @@ jobs:
 
       # Generate Lighthouse badges
       - name: Generate Lighthouse badges
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         env:
           LIGHTHOUSE_BADGES_CONFIGURATION_PATH: '.lighthouse-config.json'
         run: pnpx lighthouse-badges --url='https://cambridgemonorail.github.io/react-weapons-of-choice/' --output-path='./lighthouse-badges' -r
    
       # Clean up Lighthouse configuration file
       - name: Clean up
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: rm .lighthouse-config.json
 
       # Configure Git
       - name: Configure Git
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           git config user.name "Monorail Updater"
           git config user.email "monorail-updater@users.noreply.github.com"
 
       # Commit and push changes
       - name: Commit and push changes
+        if: env.AUTHOR_NAME != 'Monorail Updater'
         run: |
           git add ./lighthouse-badges/*
           if git diff-index --quiet HEAD; then

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 ![Best Practices](./lighthouse-badges/lighthouse_best-practices.svg)
 ![SEO](./lighthouse-badges/lighthouse_seo.svg)
 
+[View Detailed Lighthouse Report](https://htmlpreview.github.io/?https://github.com/CambridgeMonorail/react-weapons-of-choice/blob/main/lighthouse-badges/cambridgemonorail_github_io_react_weapons_of_choice_.html)
+
 ## Table of Contents
 
 - [Overview](#overview)


### PR DESCRIPTION
Implement an author check in CI workflows to prevent actions from executing if the commit author is "Monorail Updater." This change enhances the control over automated processes triggered by specific authors.