### PR TITLE
Add ActionButtons component and Storybook stories

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 - Package Management: Use pnpm exclusively for installing packages.
 - Code Quality: Write clean, modern, type-safe React functional components that adhere to best practices, emphasizing security, robustness, maintainability, readability, separation of concerns, and the DRY principle.
 - State Management: Utilize React hooks such as useState and useEffect for state management and handling side effects.
-- Styling: Apply Tailwind CSS classes for component styling and prefer shadcn/ui components for consistent UI elements.
+- Styling: Apply Tailwind CSS classes for component styling and prefer shadcn/ui components for consistent UI elements. Import shadcn components from '@rwoc/shadcnui'.
 - Monorepo Organization: Follow the Nx monorepo structure for organizing applications and libraries.
 - TypeScript Practices: Adhere to TypeScript best practices, including strict typing and the use of interfaces.
 - Testing: Implement Vitest for unit testing and Playwright for end-to-end testing.
@@ -13,3 +13,4 @@
 - Styling Consistency: Utilize shadcn theme variables for styling to ensure consistency and ease of customization. Common theme variables include bg-background, text-foreground, primary, primary-foreground, secondary, muted, and accent.
 - Component Design: Prioritize flexibility and maintainability by extending native HTML element props. Use composition to break down complex components into smaller, reusable parts, allowing customization through props, slots, or the children prop. Keep components as stateless as possible, delegating state management to parent components or using React Context when necessary. Follow accessibility best practices and ensure styles are modular and reusable. Write concise, modular, and DRY components, using named exports to promote clarity and reusability.
 - When creating Storybook stories be sure to use the latest syntax, use StoryObj, tags: ['autodocs'], cover the possible component use caseses and make sure the stories have JSDoc comments that explain what they are, the user does not to be told they are stories but what they demonstrate.
+- Icons: Use lucide-react for icons.

--- a/libs/shadcnui-blocks/src/lib/components/action-buttons/ActionButton.stories.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/action-buttons/ActionButton.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TooltipProvider } from '@rwoc/shadcnui';
+import { ActionButton, ActionButtonProps } from './index';
+import { Beer, Coffee, Apple } from 'lucide-react';
+
+const meta: Meta<typeof ActionButton> = {
+  title: 'Shadcnui Blocks/ActionButton',
+  component: ActionButton,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: { control: 'object' },
+    label: { control: 'text' },
+    onClick: { action: 'clicked' },
+    tooltip: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionButton>;
+
+/**
+ * Default story for the ActionButton component.
+ * This example shows how to use the ActionButton component with different icons and labels.
+ */
+export const DefaultActionButton: Story = {
+  name: 'Default ActionButton',
+  render: (args: ActionButtonProps) => (
+    <TooltipProvider>
+      <ActionButton {...args} />
+    </TooltipProvider>
+  ),
+  args: {
+    icon: <Beer />,
+    label: 'Beer',
+    tooltip: 'Click for beer',
+  },
+};
+
+/**
+ * CustomIcon story for the ActionButton component.
+ * This example shows how to use the ActionButton component with a custom icon.
+ */
+export const CustomIconActionButton: Story = {
+  name: 'Custom Icon ActionButton',
+  render: (args: ActionButtonProps) => (
+    <TooltipProvider>
+      <ActionButton {...args} />
+    </TooltipProvider>
+  ),
+  args: {
+    icon: <Coffee />,
+    label: 'Coffee',
+    tooltip: 'Click for coffee',
+  },
+};
+
+/**
+ * CustomTooltip story for the ActionButton component.
+ * This example shows how to use the ActionButton component with a custom tooltip.
+ */
+export const CustomTooltipActionButton: Story = {
+  name: 'Custom Tooltip ActionButton',
+  render: (args: ActionButtonProps) => (
+    <TooltipProvider>
+      <ActionButton {...args} />
+    </TooltipProvider>
+  ),
+  args: {
+    icon: <Apple />,
+    label: 'Apple',
+    tooltip: 'Click for apple',
+  },
+};

--- a/libs/shadcnui-blocks/src/lib/components/action-buttons/ActionButtons.stories.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/action-buttons/ActionButtons.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActionButton, ActionButtons, ActionButtonProps, ActionButtonsProps } from './index';
+import { FaBeer, FaCoffee, FaApple } from 'react-icons/fa';
+
+const meta: Meta<typeof ActionButton> = {
+  title: 'Shadcnui Blocks/ActionButton',
+  component: ActionButton,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: { control: 'object' },
+    label: { control: 'text' },
+    onClick: { action: 'clicked' },
+    tooltip: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionButton>;
+
+/**
+ * Default story for the ActionButton component.
+ * This example shows how to use the ActionButton component with different icons and labels.
+ */
+export const Default: Story = {
+  name: 'Default',
+  render: (args: ActionButtonProps) => <ActionButton {...args} />,
+  args: {
+    icon: <FaBeer />,
+    label: 'Beer',
+    tooltip: 'Click for beer',
+  },
+};
+
+/**
+ * CustomIcon story for the ActionButton component.
+ * This example shows how to use the ActionButton component with a custom icon.
+ */
+export const CustomIcon: Story = {
+  name: 'Custom Icon',
+  render: (args: ActionButtonProps) => <ActionButton {...args} />,
+  args: {
+    icon: <FaCoffee />,
+    label: 'Coffee',
+    tooltip: 'Click for coffee',
+  },
+};
+
+/**
+ * CustomTooltip story for the ActionButton component.
+ * This example shows how to use the ActionButton component with a custom tooltip.
+ */
+export const CustomTooltip: Story = {
+  name: 'Custom Tooltip',
+  render: (args: ActionButtonProps) => <ActionButton {...args} />,
+  args: {
+    icon: <FaApple />,
+    label: 'Apple',
+    tooltip: 'Click for apple',
+  },
+};
+
+const metaButtons: Meta<typeof ActionButtons> = {
+  title: 'Shadcnui Blocks/ActionButtons',
+  component: ActionButtons,
+  tags: ['autodocs'],
+  argTypes: {
+    buttons: { control: 'object' },
+  },
+};
+
+export const ActionButtonsDefault: StoryObj<ActionButtonsProps> = {
+  name: 'Default',
+  render: (args) => <ActionButtons {...args} />,
+  args: {
+    buttons: [
+      { icon: <FaBeer />, label: 'Beer', tooltip: 'Click for beer' },
+      { icon: <FaCoffee />, label: 'Coffee', tooltip: 'Click for coffee' },
+      { icon: <FaApple />, label: 'Apple', tooltip: 'Click for apple' },
+    ],
+  },
+};
+
+/**
+ * CustomButtons story for the ActionButtons component.
+ * This example shows how to use the ActionButtons component with custom buttons.
+ */
+export const CustomButtons: StoryObj<ActionButtonsProps> = {
+  name: 'Custom Buttons',
+  render: (args) => <ActionButtons {...args} />,
+  args: {
+    buttons: [
+      { icon: <FaBeer />, label: 'Beer', tooltip: 'Click for beer' },
+      { icon: <FaCoffee />, label: 'Coffee', tooltip: 'Click for coffee' },
+      { icon: <FaApple />, label: 'Apple', tooltip: 'Click for apple' },
+    ],
+  },
+};

--- a/libs/shadcnui-blocks/src/lib/components/action-buttons/ActionButtons.stories.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/action-buttons/ActionButtons.stories.tsx
@@ -1,65 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { ActionButton, ActionButtons, ActionButtonProps, ActionButtonsProps } from './index';
-import { FaBeer, FaCoffee, FaApple } from 'react-icons/fa';
+import { TooltipProvider } from '@rwoc/shadcnui';
+import { ActionButtons, ActionButtonsProps } from './index';
+import { Beer, Coffee, Apple } from 'lucide-react';
 
-const meta: Meta<typeof ActionButton> = {
-  title: 'Shadcnui Blocks/ActionButton',
-  component: ActionButton,
-  tags: ['autodocs'],
-  argTypes: {
-    icon: { control: 'object' },
-    label: { control: 'text' },
-    onClick: { action: 'clicked' },
-    tooltip: { control: 'text' },
-  },
-};
-
-export default meta;
-type Story = StoryObj<typeof ActionButton>;
-
-/**
- * Default story for the ActionButton component.
- * This example shows how to use the ActionButton component with different icons and labels.
- */
-export const Default: Story = {
-  name: 'Default',
-  render: (args: ActionButtonProps) => <ActionButton {...args} />,
-  args: {
-    icon: <FaBeer />,
-    label: 'Beer',
-    tooltip: 'Click for beer',
-  },
-};
-
-/**
- * CustomIcon story for the ActionButton component.
- * This example shows how to use the ActionButton component with a custom icon.
- */
-export const CustomIcon: Story = {
-  name: 'Custom Icon',
-  render: (args: ActionButtonProps) => <ActionButton {...args} />,
-  args: {
-    icon: <FaCoffee />,
-    label: 'Coffee',
-    tooltip: 'Click for coffee',
-  },
-};
-
-/**
- * CustomTooltip story for the ActionButton component.
- * This example shows how to use the ActionButton component with a custom tooltip.
- */
-export const CustomTooltip: Story = {
-  name: 'Custom Tooltip',
-  render: (args: ActionButtonProps) => <ActionButton {...args} />,
-  args: {
-    icon: <FaApple />,
-    label: 'Apple',
-    tooltip: 'Click for apple',
-  },
-};
-
-const metaButtons: Meta<typeof ActionButtons> = {
+const meta: Meta<typeof ActionButtons> = {
   title: 'Shadcnui Blocks/ActionButtons',
   component: ActionButtons,
   tags: ['autodocs'],
@@ -68,14 +12,24 @@ const metaButtons: Meta<typeof ActionButtons> = {
   },
 };
 
+export default meta;
+
+/**
+ * Default story for the ActionButtons component.
+ * This example shows how to use the ActionButtons component with different buttons.
+ */
 export const ActionButtonsDefault: StoryObj<ActionButtonsProps> = {
-  name: 'Default',
-  render: (args) => <ActionButtons {...args} />,
+  name: 'Default ActionButtons',
+  render: (args) => (
+    <TooltipProvider>
+      <ActionButtons {...args} />
+    </TooltipProvider>
+  ),
   args: {
     buttons: [
-      { icon: <FaBeer />, label: 'Beer', tooltip: 'Click for beer' },
-      { icon: <FaCoffee />, label: 'Coffee', tooltip: 'Click for coffee' },
-      { icon: <FaApple />, label: 'Apple', tooltip: 'Click for apple' },
+      { icon: <Beer />, label: 'Beer', tooltip: 'Click for beer' },
+      { icon: <Coffee />, label: 'Coffee', tooltip: 'Click for coffee' },
+      { icon: <Apple />, label: 'Apple', tooltip: 'Click for apple' },
     ],
   },
 };
@@ -84,14 +38,18 @@ export const ActionButtonsDefault: StoryObj<ActionButtonsProps> = {
  * CustomButtons story for the ActionButtons component.
  * This example shows how to use the ActionButtons component with custom buttons.
  */
-export const CustomButtons: StoryObj<ActionButtonsProps> = {
-  name: 'Custom Buttons',
-  render: (args) => <ActionButtons {...args} />,
+export const CustomButtonsActionButtons: StoryObj<ActionButtonsProps> = {
+  name: 'Custom Buttons ActionButtons',
+  render: (args) => (
+    <TooltipProvider>
+      <ActionButtons {...args} />
+    </TooltipProvider>
+  ),
   args: {
     buttons: [
-      { icon: <FaBeer />, label: 'Beer', tooltip: 'Click for beer' },
-      { icon: <FaCoffee />, label: 'Coffee', tooltip: 'Click for coffee' },
-      { icon: <FaApple />, label: 'Apple', tooltip: 'Click for apple' },
+      { icon: <Beer />, label: 'Beer', tooltip: 'Click for beer' },
+      { icon: <Coffee />, label: 'Coffee', tooltip: 'Click for coffee' },
+      { icon: <Apple />, label: 'Apple', tooltip: 'Click for apple' },
     ],
   },
 };

--- a/libs/shadcnui-blocks/src/lib/components/action-buttons/index.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/action-buttons/index.tsx
@@ -1,27 +1,67 @@
-import React from "react";
-import { Button } from "@/components/ui/button";
-import { Tooltip } from "@/components/ui/tooltip";
+import { ReactNode, FC } from 'react';
+import {
+  Button,
+  Tooltip,
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+} from '@rwoc/shadcnui';
 
+/**
+ * Props for the ActionButton component.
+ *
+ * This interface defines the structure for the props that are passed to the ActionButton component,
+ * which includes an icon, label, onClick handler, and optional tooltip.
+ */
 export interface ActionButtonProps {
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   onClick?: () => void;
   tooltip?: string;
 }
 
-export const ActionButton: React.FC<ActionButtonProps> = ({ icon, label, onClick, tooltip }) => {
+/**
+ * ActionButton component.
+ *
+ * This component renders a button with an icon and an optional tooltip.
+ *
+ * ## Usage Guidelines:
+ *
+ * The ActionButton component is designed to be used in contexts where a button with an icon and
+ * optional tooltip is needed. It provides a consistent styling and accessibility features.
+ */
+export const ActionButton: FC<ActionButtonProps> = ({
+  icon,
+  label,
+  onClick,
+  tooltip,
+}) => {
   return (
-    <Tooltip content={tooltip}>
-      <Button variant="ghost" size="icon" onClick={onClick} aria-label={label}>
-        {icon}
-        <span className="sr-only">{label}</span>
-      </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClick}
+          aria-label={label}
+        >
+          {icon}
+          <span className="sr-only">{label}</span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{tooltip}</p>
+      </TooltipContent>
     </Tooltip>
   );
 };
 
 /**
  * Props for the ActionButtons component.
+ *
+ * This interface defines the structure for the props that are passed to the ActionButtons component,
+ * which includes an array of ActionButtonProps objects. Each object in the array represents a button
+ * with its own icon, label, onClick handler, and optional tooltip.
  */
 export interface ActionButtonsProps {
   buttons: ActionButtonProps[];
@@ -29,15 +69,21 @@ export interface ActionButtonsProps {
 
 /**
  * ActionButtons component.
- * 
+ *
  * This component renders a sequence of ActionButton components.
+ *
+ * ## Usage Guidelines:
+ *
+ * The ActionButtons component is primarily designed to be used in a header or other contexts where
+ * a number of action buttons need to be rendered together. It provides a convenient way to group
+ * multiple action buttons with consistent styling and optional tooltips.
  */
-export const ActionButtons: React.FC<ActionButtonsProps> = ({ buttons }) => {
+export const ActionButtons: FC<ActionButtonsProps> = ({ buttons }) => {
   return (
-    <>
+    <TooltipProvider>
       {buttons.map((button, index) => (
         <ActionButton key={index} {...button} />
       ))}
-    </>
+    </TooltipProvider>
   );
 };

--- a/libs/shadcnui-blocks/src/lib/components/action-buttons/index.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/action-buttons/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
+
+export interface ActionButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick?: () => void;
+  tooltip?: string;
+}
+
+export const ActionButton: React.FC<ActionButtonProps> = ({ icon, label, onClick, tooltip }) => {
+  return (
+    <Tooltip content={tooltip}>
+      <Button variant="ghost" size="icon" onClick={onClick} aria-label={label}>
+        {icon}
+        <span className="sr-only">{label}</span>
+      </Button>
+    </Tooltip>
+  );
+};
+
+/**
+ * Props for the ActionButtons component.
+ */
+export interface ActionButtonsProps {
+  buttons: ActionButtonProps[];
+}
+
+/**
+ * ActionButtons component.
+ * 
+ * This component renders a sequence of ActionButton components.
+ */
+export const ActionButtons: React.FC<ActionButtonsProps> = ({ buttons }) => {
+  return (
+    <>
+      {buttons.map((button, index) => (
+        <ActionButton key={index} {...button} />
+      ))}
+    </>
+  );
+};

--- a/libs/shadcnui-blocks/src/lib/components/index.ts
+++ b/libs/shadcnui-blocks/src/lib/components/index.ts
@@ -13,3 +13,4 @@ export * from './testimonials/index';
 export * from './stats-block/StatItem';
 export * from './stats-block/StatsBlock';
 export * from './number-and-secondary-stat/index';
+export * from './action-buttons/index';


### PR DESCRIPTION
Fixes #197

Add ActionButton and ActionButtons components with Storybook stories

* **ActionButton Component**
  - Implement `ActionButton` component in `libs/shadcnui-blocks/src/lib/components/action-buttons/index.tsx`
  - Add props: `icon`, `label`, `onClick`, and `tooltip`
  - Add accessibility features such as `aria-label` and keyboard accessibility
  - Add support for tooltips and custom icons
  - Write JSDoc comments for all props and components

* **ActionButtons Component**
  - Implement `ActionButtons` component in `libs/shadcnui-blocks/src/lib/components/action-buttons/index.tsx`
  - Add `buttons` prop
  - Write JSDoc comments for all props and components

* **Storybook Stories**
  - Create Storybook stories for `ActionButton` and `ActionButtons` components in `libs/shadcnui-blocks/src/lib/components/action-buttons/ActionButtons.stories.tsx`
  - Demonstrate single `ActionButton` with different icons and labels
  - Demonstrate `ActionButtons` with multiple buttons showcasing various configurations
  - Add JSDoc comments explaining what the stories demonstrate

* **Exports**
  - Export `ActionButton` and `ActionButtons` components in `libs/shadcnui-blocks/src/lib/components/index.ts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/198?shareId=df7d0086-f20e-4081-8553-94d497c4aa17).