### PR TITLE
Add Logo component with optional display name

### DIFF
--- a/libs/shadcnui-blocks/src/lib/components/logo/Logo.stories.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/logo/Logo.stories.tsx
@@ -139,3 +139,33 @@ export const WithCustomClassNames: Story = {
     nameClassName: 'custom-name-class',
   },
 };
+
+/**
+ * Demonstrates the Logo component with custom sizes.
+ */
+export const CustomSizes: Story = {
+  name: 'Custom Sizes',
+  render: (args: LogoProps) => <Logo {...args} />,
+  args: {
+    name: 'shadcn',
+    width: '150px',
+    height: '150px',
+    fill: 'currentColor',
+  },
+};
+
+/**
+ * Demonstrates the Logo component with custom class names for both logo and name.
+ */
+export const CustomClassNames: Story = {
+  name: 'Custom Class Names',
+  render: (args: LogoProps) => <Logo {...args} />,
+  args: {
+    name: 'shadcn',
+    width: '100px',
+    height: '100px',
+    fill: 'currentColor',
+    logoClassName: 'custom-logo-class',
+    nameClassName: 'custom-name-class',
+  },
+};

--- a/libs/shadcnui-blocks/src/lib/components/logo/Logo.stories.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/logo/Logo.stories.tsx
@@ -15,6 +15,9 @@ const meta: Meta<typeof Logo> = {
     width: { control: 'text' },
     height: { control: 'text' },
     fill: { control: 'color' },
+    displayName: { control: 'text' },
+    logoClassName: { control: 'text' },
+    nameClassName: { control: 'text' },
   },
 };
 
@@ -102,5 +105,37 @@ export const Storybook: Story = {
     width: '100px',
     height: '100px',
     fill: 'currentColor',
+  },
+};
+
+/**
+ * Demonstrates the Logo component with a display name.
+ */
+export const WithDisplayName: Story = {
+  name: 'With Display Name',
+  render: (args: LogoProps) => <Logo {...args} />,
+  args: {
+    name: 'react',
+    width: '100px',
+    height: '100px',
+    fill: 'currentColor',
+    displayName: 'React',
+  },
+};
+
+/**
+ * Demonstrates the Logo component with custom class names for logo and name.
+ */
+export const WithCustomClassNames: Story = {
+  name: 'With Custom Class Names',
+  render: (args: LogoProps) => <Logo {...args} />,
+  args: {
+    name: 'tailwind',
+    width: '100px',
+    height: '100px',
+    fill: 'currentColor',
+    displayName: 'Tailwind CSS',
+    logoClassName: 'custom-logo-class',
+    nameClassName: 'custom-name-class',
   },
 };

--- a/libs/shadcnui-blocks/src/lib/components/logo/index.tsx
+++ b/libs/shadcnui-blocks/src/lib/components/logo/index.tsx
@@ -117,12 +117,23 @@ interface LogoProps extends Omit<SVGProps<SVGSVGElement>, 'title'> {
   name: keyof typeof logoMap;
   title?: string;
   ariaLabel?: string;
+  logoClassName?: string; // Optional custom class name for logo
+  nameClassName?: string; // Optional custom class name for name
+  displayName?: string; // Optional display name
 }
 
 /**
  * Logo component that renders different logos based on the provided name.
  */
-const Logo: FC<LogoProps> = ({ name, title, ariaLabel, ...props }) => {
+const Logo: FC<LogoProps> = ({
+  name,
+  title,
+  ariaLabel,
+  logoClassName,
+  nameClassName,
+  displayName,
+  ...props
+}) => {
   const LogoComponent = logoMap[name];
 
   if (!LogoComponent) {
@@ -131,9 +142,21 @@ const Logo: FC<LogoProps> = ({ name, title, ariaLabel, ...props }) => {
   }
 
   return (
-    <LogoWrapper title={title} ariaLabel={ariaLabel} {...props}>
-      <LogoComponent />
-    </LogoWrapper>
+    <div className="flex items-center space-x-2">
+      <LogoWrapper
+        title={title}
+        ariaLabel={ariaLabel}
+        className={logoClassName}
+        {...props}
+      >
+        <LogoComponent />
+      </LogoWrapper>
+      {displayName && (
+        <span className={`text-lg font-semibold ${nameClassName}`}>
+          {displayName}
+        </span>
+      )}
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixes #199

Add support for displaying a logo image with an optional name in a horizontal row in the `Logo` component.

* **Logo Component Changes:**
  - Add `logoClassName`, `nameClassName`, and `displayName` props to `LogoProps` interface.
  - Update `Logo` component to render `displayName` in a horizontal row with the logo image.
  - Apply `logoClassName` and `nameClassName` to the respective elements.

* **Storybook Stories:**
  - Add Storybook story for `Logo` component with `displayName` prop.
  - Add Storybook story for `Logo` component with custom `logoClassName` and `nameClassName`.
  - Ensure stories demonstrate usage with and without the `displayName` prop.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/200?shareId=258d9ba1-31fd-4880-9d38-50ab5c68b2e7).