### PR TITLE
Fix sidebar click behavior when collapsed

### DIFF
--- a/libs/shell/src/lib/nav/NavMain.tsx
+++ b/libs/shell/src/lib/nav/NavMain.tsx
@@ -12,6 +12,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  useSidebar,
 } from '@rwoc/shadcnui';
 import { ChevronRight, type LucideIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
@@ -30,6 +31,8 @@ export function NavMain({
     }[];
   }[];
 }) {
+  const { state, toggleSidebar } = useSidebar();
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Navigation</SidebarGroupLabel>
@@ -43,7 +46,14 @@ export function NavMain({
           >
             <SidebarMenuItem>
               <CollapsibleTrigger asChild>
-                <SidebarMenuButton tooltip={item.title}>
+                <SidebarMenuButton
+                  tooltip={item.title}
+                  onClick={() => {
+                    if (state === 'collapsed') {
+                      toggleSidebar();
+                    }
+                  }}
+                >
                   {item.icon && <item.icon />}
                   <span>{item.title}</span>
                   <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />


### PR DESCRIPTION
Fixes #155

Add functionality to expand the sidebar when an icon is clicked in the collapsed state.

* Import `useSidebar` from `@rwoc/shadcnui` in `libs/shell/src/lib/nav/NavMain.tsx`.
* Add `const { state, toggleSidebar } = useSidebar();` in the `NavMain` component.
* Add `onClick` event handler to `SidebarMenuButton` to check the sidebar state and call `toggleSidebar()` if it is collapsed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CambridgeMonorail/react-weapons-of-choice/pull/202?shareId=42893144-e407-4544-abfe-8740e41a9f4b).